### PR TITLE
Add logout button to settings page

### DIFF
--- a/apps/dashboard/src/app/[lang]/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/settings/page.tsx
@@ -2,7 +2,9 @@
 
 import { Card } from "@dukkani/ui/components/card";
 import { Icons } from "@dukkani/ui/components/icons";
+import { Separator } from "@dukkani/ui/components/separator";
 import Link from "next/link";
+import { LogoutButton } from "@/components/app/settings/logout-button";
 import { RoutePaths } from "@/shared/config/routes";
 
 export default function SettingsPage() {
@@ -73,6 +75,10 @@ export default function SettingsPage() {
           </Card>
         </Link>
       </div>
+
+      <Separator className="my-6" />
+
+      <LogoutButton />
     </div>
   );
 }

--- a/apps/dashboard/src/components/app/settings/logout-button.tsx
+++ b/apps/dashboard/src/components/app/settings/logout-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@dukkani/ui/components/alert-dialog";
+import { Button } from "@dukkani/ui/components/button";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { authClient } from "@/shared/api/auth-client";
+import { RoutePaths } from "@/shared/config/routes";
+
+export function LogoutButton() {
+  const router = useRouter();
+  const [isPending, setIsPending] = useState(false);
+
+  function handleSignOut(e: React.MouseEvent) {
+    e.preventDefault();
+    setIsPending(true);
+    authClient.signOut({
+      fetchOptions: {
+        onSuccess: () => {
+          router.push(RoutePaths.AUTH.LOGIN.url);
+        },
+        onError: () => {
+          setIsPending(false);
+        },
+      },
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" className="w-full sm:w-auto">
+          Log out
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Log out of your account?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You will be redirected to the login page. Any unsaved changes in
+            other tabs may be lost.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            isLoading={isPending}
+            onClick={handleSignOut}
+          >
+            Log out
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/dashboard/src/components/app/settings/logout-button.tsx
+++ b/apps/dashboard/src/components/app/settings/logout-button.tsx
@@ -13,12 +13,14 @@ import {
 } from "@dukkani/ui/components/alert-dialog";
 import { Button } from "@dukkani/ui/components/button";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { authClient } from "@/shared/api/auth-client";
 import { RoutePaths } from "@/shared/config/routes";
 
 export function LogoutButton() {
   const router = useRouter();
+  const t = useTranslations("settings.logout");
   const [isPending, setIsPending] = useState(false);
 
   function handleSignOut(e: React.MouseEvent) {
@@ -40,25 +42,26 @@ export function LogoutButton() {
     <AlertDialog>
       <AlertDialogTrigger asChild>
         <Button variant="destructive" className="w-full sm:w-auto">
-          Log out
+          {t("button")}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Log out of your account?</AlertDialogTitle>
-          <AlertDialogDescription>
-            You will be redirected to the login page. Any unsaved changes in
-            other tabs may be lost.
-          </AlertDialogDescription>
+          <AlertDialogTitle>{t("title")}</AlertDialogTitle>
+          <AlertDialogDescription>{t("description")}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            isLoading={isPending}
-            onClick={handleSignOut}
-          >
-            Log out
+          <AlertDialogCancel disabled={isPending}>
+            {t("cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button
+              variant="destructive"
+              isLoading={isPending}
+              onClick={handleSignOut}
+            >
+              {t("confirm")}
+            </Button>
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/common/src/locale/dashboard/ar.json
+++ b/packages/common/src/locale/dashboard/ar.json
@@ -46,6 +46,13 @@
     }
   },
   "settings": {
+    "logout": {
+      "button": "تسجيل الخروج",
+      "title": "تسجيل الخروج من حسابك؟",
+      "description": "سيتم إعادة توجيهك إلى صفحة تسجيل الدخول. قد تُفقد التغييرات غير المحفوظة في علامات التبويب الأخرى.",
+      "cancel": "إلغاء",
+      "confirm": "تسجيل الخروج"
+    },
     "telegram": {
       "title": "Telegram Notifications",
       "description": "Link your Telegram account to receive instant order notifications",

--- a/packages/common/src/locale/dashboard/en.json
+++ b/packages/common/src/locale/dashboard/en.json
@@ -46,6 +46,13 @@
     }
   },
   "settings": {
+    "logout": {
+      "button": "Log out",
+      "title": "Log out of your account?",
+      "description": "You will be redirected to the login page. Any unsaved changes in other tabs may be lost.",
+      "cancel": "Cancel",
+      "confirm": "Log out"
+    },
     "telegram": {
       "title": "Telegram Notifications",
       "description": "Link your Telegram account to receive instant order notifications",

--- a/packages/common/src/locale/dashboard/fr.json
+++ b/packages/common/src/locale/dashboard/fr.json
@@ -46,6 +46,13 @@
     }
   },
   "settings": {
+    "logout": {
+      "button": "Se déconnecter",
+      "title": "Se déconnecter de votre compte ?",
+      "description": "Vous serez redirigé vers la page de connexion. Les modifications non enregistrées dans d'autres onglets peuvent être perdues.",
+      "cancel": "Annuler",
+      "confirm": "Se déconnecter"
+    },
     "telegram": {
       "title": "Notifications Telegram",
       "description": "Liez votre compte Telegram pour recevoir des notifications de commande instantanées",


### PR DESCRIPTION
Adds a LogoutButton component below the settings grid, behind an AlertDialog confirmation, with loading state while signOut is in flight. Closes #422

## 🧠 Overview
<!-- Briefly describe what this PR does and why -->

---

## ✅ Pre-merge Checklist

### Code Quality
- [ ] Self-reviewed the code thoroughly
- [ ] Follows project rules and conventions
- [ ] Builds and runs locally without issues
- [ ] Resolved all AI/code review comments

---

## 🧪 Testing Checklist

### Core Flow (Preview Environment)
- [ ] Completed full onboarding flow:
  - [ ] Create account
  - [ ] Create store

- [ ] Product lifecycle:
  - [ ] Create product
  - [ ] Archive product
  - [ ] Unarchive product
  - [ ] Delete product

---

### Storefront Behavior
- [ ] Storefront disappears when product is archived
- [ ] Storefront reappears when product is unarchived
- [ ] Product is removed from storefront after deletion

---

### Storage Validation
- [ ] Verified product deletion in Cloudflare R2

---

### Seeder / Demo Accounts
- [ ] Logged in using a seeded/demo account
- [ ] Performed product actions:
  - [ ] Create product
  - [ ] Archive product
  - [ ] Delete product

---

## 🔍 Additional Notes
<!-- Anything reviewers should be aware of -->