### PR TITLE
perf: dedupe session context, enable cookieCache, dedupe storefront fetch

### DIFF
--- a/apps/api/src/app/api/[[...rest]]/route.ts
+++ b/apps/api/src/app/api/[[...rest]]/route.ts
@@ -89,9 +89,10 @@ async function handleRequest(req: NextRequest) {
   let response: Response;
 
   try {
+    const context = await createContext(req.headers);
     const rpcResult = await rpcHandler.handle(req, {
       prefix: "/api",
-      context: await createContext(req.headers),
+      context,
     });
     if (rpcResult.response) {
       response = rpcResult.response;
@@ -101,7 +102,7 @@ async function handleRequest(req: NextRequest) {
     } else {
       const apiResult = await apiHandler.handle(req, {
         prefix: "/api",
-        context: await createContext(req.headers),
+        context,
       });
       if (apiResult.response) {
         response = apiResult.response;

--- a/apps/storefront/src/shared/api/orpc.ts
+++ b/apps/storefront/src/shared/api/orpc.ts
@@ -2,6 +2,7 @@ import { getApiUrl } from "@dukkani/env/get-api-url";
 import type { AppRouter, StorefrontRouterClient } from "@dukkani/orpc";
 import { createORPCClientUtils } from "@dukkani/orpc/client";
 import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
 import { env } from "@/env";
 
 export function makeQueryClient() {
@@ -50,9 +51,15 @@ export const orpc = getORPCClient().orpc;
 
 let browserQueryClient: QueryClient | undefined;
 
+// On the server, `cache()` memoizes the QueryClient for the lifetime of a
+// single request/render pass, so the root layout's prefetch and a page's own
+// fetchQuery for the same input share one client instead of each issuing an
+// independent DB round trip.
+const getServerQueryClient = cache(makeQueryClient);
+
 export function getQueryClient() {
   if (typeof window === "undefined") {
-    return makeQueryClient();
+    return getServerQueryClient();
   }
   if (!browserQueryClient) {
     browserQueryClient = makeQueryClient();

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -57,6 +57,16 @@ export function createAuth(
         },
       },
     },
+    session: {
+      // Avoids a DB round trip on every session read (every oRPC request) by
+      // trusting a short-lived signed cookie between checks. Safe here: no
+      // impersonation/ban/role flow in this codebase depends on sub-5-minute
+      // session freshness.
+      cookieCache: {
+        enabled: true,
+        maxAge: 5 * 60,
+      },
+    },
     emailAndPassword: {
       enabled: true,
       password: {


### PR DESCRIPTION
## Summary
Phase 1 of the Fluid Active CPU reduction effort tracked in #461. Three small, isolated, verified-safe fixes:

- **`apps/api/src/app/api/[[...rest]]/route.ts`** — `createContext()` (resolves the Better Auth session) was awaited twice per request when the RPC handler didn't match and fell through to the OpenAPI handler. Now computed once and reused for both `.handle()` calls.
- **`packages/auth/src/index.ts`** — enabled `session.cookieCache` (5 min TTL). Confirmed via a full repo grep that no impersonation/ban/role-based authorization flow depends on sub-5-minute session freshness, so this is safe. Turns every session read into a cheap in-memory cookie check instead of a DB round trip.
- **`apps/storefront/src/shared/api/orpc.ts`** — `getQueryClient()` returned a brand-new `QueryClient` on every server-side call, so the root layout's `getBySlugPublic` prefetch and the page's own `fetchQuery` for the same data each independently hit the DB. Wrapped in `React.cache()` (the standard TanStack Query + Next.js RSC pattern) so both share one client per request.

Full root-cause analysis and research notes: #461, #462.

## Test plan
- [x] `pnpm turbo run check-types` passes for `@dukkani/api`, `@dukkani/auth`, `@dukkani/storefront`
- [x] `pnpm turbo run build` passes for both apps
- [x] `biome check` clean on all three touched files
- [ ] Manual verification on preview deploy: store page loads correctly, login/logout still works, dashboard `requireAuth`-gated routes still enforce auth
- [ ] Confirm via a temporary log (or Vercel runtime logs) that `getStoreBySlugPublic` is invoked once per page load, not twice
- [ ] Post-merge: watch Fluid Active CPU graph on `dukkani-api`/`dukkani-storefront` in Vercel dashboard for 24-48h

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling by reusing the same request context across API paths.
  * Reduced repeated server-side query client creation, which should help improve server rendering efficiency.
  * Added short-lived session caching to speed up session checks and reduce repeated reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->