### PR TITLE
perf: add short-TTL cache to getBySlugPublic

### DIFF
--- a/packages/orpc/src/routers/storefront/store.ts
+++ b/packages/orpc/src/routers/storefront/store.ts
@@ -13,9 +13,27 @@ import {
 } from "@dukkani/common/services";
 import { database } from "@dukkani/db";
 import { ORPCError } from "@orpc/server";
+import { unstable_cache } from "next/cache";
 import { z } from "zod";
 import { rateLimitPublicSafe } from "../../middleware/rate-limit";
 import { baseProcedure, publicProcedure } from "../../procedures";
+
+// Time-based cache, no tag invalidation: dashboard edits (product/store/bundle
+// writes) become visible on the storefront within this window automatically.
+// Deliberately not using revalidateTag here — there's a hidden cross-entity
+// dependency (editing a plain product can affect a different bundle's cached
+// stock via recomputeBundlesReferencingProducts) that would make tag wiring
+// across ~30 mutation call sites error-prone with no existing test coverage.
+// Order creation re-validates stock/price fresh from the DB independent of
+// this cache, so staleness here cannot cause an overselling/pricing bug.
+const STORE_PUBLIC_CACHE_REVALIDATE_SECONDS = 20;
+
+const getCachedStoreBySlugPublic = unstable_cache(
+  async (slug: string, productPage?: number, productLimit?: number) =>
+    StoreService.getStoreBySlugPublic(slug, { productPage, productLimit }),
+  ["store-by-slug-public"],
+  { revalidate: STORE_PUBLIC_CACHE_REVALIDATE_SECONDS },
+);
 
 export const storeRouter = {
   getBySlugPublic: baseProcedure
@@ -23,10 +41,11 @@ export const storeRouter = {
     .input(getStoreBySlugPublicInputSchema)
     .output(storePublicOutputSchema)
     .handler(async ({ input }) => {
-      return await StoreService.getStoreBySlugPublic(input.slug, {
-        productPage: input.productPage,
-        productLimit: input.productLimit,
-      });
+      return await getCachedStoreBySlugPublic(
+        input.slug,
+        input.productPage,
+        input.productLimit,
+      );
     }),
 
   subscribeToLaunch: publicProcedure


### PR DESCRIPTION
## Summary
Phase 2 of the Fluid Active CPU reduction effort tracked in #461. Implemented now that #464 (Phase 1) has landed on `main`.

- **`packages/orpc/src/routers/storefront/store.ts`** — wraps `StoreService.getStoreBySlugPublic(...)` in Next.js `unstable_cache` (not `"use cache"` — `cacheComponents` is `false` in this repo's Next config, so the new directive isn't available; `unstable_cache` is the correct stable API here).
- Cache key: derived from `unstable_cache`'s own args-based keying (`slug`, `productPage`, `productLimit` — the complete input surface of the procedure, no locale/auth/filters).
- TTL: `revalidate: 20` seconds, time-based only, no `revalidateTag`. A dashboard edit becomes visible on the storefront within ~20s automatically.

### Pre-flight check (completed, as required by the plan)
Verified that `OrderService.createOrderPublic` (`packages/common/src/services/order.service.ts:367-615`) independently re-validates stock and price fresh from the DB inside its own transaction — it never trusts client-supplied or cached values. `ProductService.checkStockAvailability` and `ProductService.getOrderItemPrices` both re-query the current published version at order-creation time, and insufficient stock throws before any row is written. **A stale cached `getBySlugPublic` read cannot cause an overselling or pricing bug.**

(Noted separately, unrelated to this change: the stock check-then-decrement in `createOrderPublic` is two statements in one transaction rather than a single atomic conditional update, so there's a theoretical race between two concurrent checkouts under Postgres Read Committed. Pre-existing, independent of this cache — not fixing here, worth its own follow-up if it becomes a real issue.)

## Why time-based, not tag-based
Per the plan/issue discussion: `recomputeBundlesReferencingProducts` means editing a plain product can silently affect a *different* bundle's cached stock, which would make `revalidateTag` wiring across the ~30 mutation call sites in `store.service.ts`/`product.service.ts`/`product-version.service.ts`/`bundle.service.ts` error-prone, especially with zero existing test coverage on any of these paths. Time-based TTL avoids touching any of them.

## Test plan
- [x] `pnpm turbo run check-types` passes for `@dukkani/orpc`, `@dukkani/api`, `@dukkani/storefront`
- [x] `pnpm turbo run build` passes for both apps
- [x] `biome check` clean on the touched file
- [ ] Preview: load a store page, edit a product in the dashboard, reload immediately (should show old data — cache active), reload after 20s (should show new data — TTL revalidation works)
- [ ] Preview: place a real test order, confirm stock decrements correctly regardless of cache state (validates the pre-flight finding end-to-end)
- [ ] Post-merge: watch Fluid Active CPU graph on `dukkani-api` for 24-48h — this endpoint is ~99% of current traffic, so this is the change expected to move the needle most

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)