### PR TITLE
fix: guard FlagComponent against undefined country

### DIFF
--- a/packages/ui/src/components/country.tsx
+++ b/packages/ui/src/components/country.tsx
@@ -11,7 +11,7 @@ export function FlagComponent({
   // (e.g. mid-typing an international number before a country is detected
   // from the digits), even though its own types mark it as required.
   if (!country) {
-    return <div className="h-[15px] w-5 shrink-0 rounded-xs bg-muted" />;
+    return <div className="h-[15px] w-5 shrink-0 rounded-xs bg-muted" aria-hidden="true" />;
   }
 
   return (

--- a/packages/ui/src/components/country.tsx
+++ b/packages/ui/src/components/country.tsx
@@ -4,9 +4,16 @@ export function FlagComponent({
   country,
   countryName,
 }: {
-  country: string;
+  country: string | undefined;
   countryName: string;
 }) {
+  // `react-phone-number-input` can render this with `country` undefined
+  // (e.g. mid-typing an international number before a country is detected
+  // from the digits), even though its own types mark it as required.
+  if (!country) {
+    return <div className="h-[15px] w-5 shrink-0 rounded-xs bg-muted" />;
+  }
+
   return (
     <Image
       src={`https://flagcdn.com/w20/${country.toLowerCase()}.png`}


### PR DESCRIPTION
## Summary
Fixes #466 — a `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` crash in `packages/ui/src/components/country.tsx:12` that takes down the storefront checkout page.

**Root cause:** `react-phone-number-input`'s internal country-selection state can legitimately be `undefined` at points during user interaction (e.g. mid-typing an international number before a country is detected from the digits) — this happens even though the library's own `FlagProps.country` type declares it as required, and even though `checkout-form.tsx` correctly passes `defaultCountry="TN"`. `FlagComponent` called `country.toLowerCase()` unconditionally with no guard, so any render where the country selector had no resolved country crashed the whole page.

**Fix:** render a neutral placeholder (`bg-muted` block matching the flag's dimensions, consistent with existing placeholder patterns elsewhere in this design system, e.g. `avatar.tsx`) instead of throwing when `country` is falsy.

## Test plan
- [x] `pnpm turbo run check-types` passes for `@dukkani/ui`, `@dukkani/storefront`, `@dukkani/dashboard`
- [x] `biome check` clean on the touched file
- [ ] Manual verification on preview: open storefront checkout, use the phone field to trigger the undefined-country state (e.g. type `+` then rapidly delete/retype digits) and confirm the page no longer crashes

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)