### PR TITLE
chore(i18n): re-trigger Languine translation workflow

### DIFF
--- a/packages/common/src/locale/storefront/en.json
+++ b/packages/common/src/locale/storefront/en.json
@@ -1,7 +1,7 @@
 {
   "storefront": {
     "title": "Storefront",
-    "description": "Storefront description",
+    "description": "Storefront description.",
     "store": {
       "owner": {
         "title": "Store Owner"


### PR DESCRIPTION
## Summary
- The self-hosted Languine translation workflow (`.github/workflows/languine.yml`) failed on its last run with `Translation process failed: Body already used`.
- Root cause: the Supabase database backing the self-hosted Languine instance was paused, so the tRPC `jobs.startJob` call on the Languine server errored out before a trigger.dev run was ever created (hence nothing showing up in the trigger.dev dashboard). A bug in the Languine CLI's tRPC fetch wrapper (`packages/cli/src/utils/api.ts`) then masked that real error behind a generic `Body already used` message, since it reads the error response body and then hands the same (already-consumed) `Response` back to `httpBatchLink`.
- Supabase is unpaused now. This PR makes a trivial content tweak to `packages/common/src/locale/storefront/en.json` (added a trailing period) so the workflow's path filter fires again on merge to `main`, confirming the pipeline is healthy end to end.

## Test plan
- [ ] Merge to `main` and confirm the `Languine Translation` workflow run succeeds
- [ ] Confirm a follow-up PR/commit lands from the Languine bot updating `fr`/`ar` translations for the changed key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the storefront English description text to include consistent punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->