### PR TITLE
ResponsivePopover component + migrate filter drawers to it

### DIFF
--- a/.cursor/rules/packages/ui.mdc
+++ b/.cursor/rules/packages/ui.mdc
@@ -152,6 +152,33 @@ const containerRef = useViewportLock({ enabled: isMobile });
 - Gate `enabled` with `useIsMobile()`; this is a mobile-Safari-specific fix and should no-op on desktop.
 - Mark the container `data-viewport-locked` (sets `touch-action: none`, see `globals.css`) and mark any internally scrollable region `data-viewport-scrollable` (restores `touch-action: pan-y`) — omitting the scrollable marker on a page-level container will silently break normal scroll gestures.
 
+### `useIsMobile(breakpoint?)`
+
+Tracks whether the viewport is narrower than `breakpoint` (default 768px) via `matchMedia`. Pass a custom breakpoint to reuse the same tracking logic for other layout switches instead of writing a second matchMedia hook — e.g. `ResponsivePopover` calls `useIsMobile(1280)` to match the dashboard shell's always-visible sidebar breakpoint.
+
+## `ResponsivePopover`
+
+### Location
+`packages/ui/src/components/responsive-popover.tsx`
+
+### Pattern
+
+Renders a `Popover` at >=1280px and a `Drawer` (bottom sheet) below that, so the same trigger/content markup can serve both mobile and desktop without a mobile/desktop content fork. Use for filter panels, quick-create forms, and other lightweight anchored surfaces — not multi-step forms or dedicated editing screens (those should stay a plain `Drawer`/`Sheet`).
+
+```tsx
+<ResponsivePopover open={open} onOpenChange={setOpen}>
+  <ResponsivePopoverTrigger asChild>
+    <Button variant="outline">Filters</Button>
+  </ResponsivePopoverTrigger>
+  <ResponsivePopoverContent>
+    {/* shared body, unchanged between mobile/desktop */}
+  </ResponsivePopoverContent>
+</ResponsivePopover>
+```
+
+- The trigger element must be rendered inside `ResponsivePopoverTrigger` (not by a sibling/parent component) — Radix `Popover` needs the trigger in its own tree to anchor correctly. If the trigger currently lives in a separate "search bar" or "select field" component, thread it in via a `trigger`/`*Trigger` render-prop (`ReactNode`) instead of an `onClick` callback — see `apps/dashboard/src/components/app/products/products-filter-drawer.tsx` and `packages/ui/src/components/forms/select-field.tsx` (`newOptionTrigger`) for the pattern.
+- `ResponsivePopoverContent` defaults to a fixed max width on desktop (unlike `PopoverContent`'s default) — override via `className` per usage.
+
 ## Styles
 
 ### Location

--- a/apps/dashboard/src/app/[lang]/(dashboard)/customers/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/customers/page.tsx
@@ -9,6 +9,7 @@ import {
   EmptyMedia,
 } from "@dukkani/ui/components/empty";
 import { Icons } from "@dukkani/ui/components/icons";
+import { InputGroupButton } from "@dukkani/ui/components/input-group";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -76,8 +77,27 @@ export default function CustomersPage() {
         <CustomersSearchBar
           value={search}
           onChange={setSearch}
-          onFilterClick={() => setFilterDrawerOpen(true)}
-          filterActive={filterActive}
+          filterTrigger={
+            <CustomersFilterDrawer
+              trigger={
+                <InputGroupButton
+                  type="button"
+                  variant={filterActive ? "default" : "ghost"}
+                  size="icon-sm"
+                  aria-label={t("filterDrawer.title")}
+                >
+                  <Icons.slidersHorizontal className="size-4" />
+                </InputGroupButton>
+              }
+              open={filterDrawerOpen}
+              onOpenChange={setFilterDrawerOpen}
+              governorates={governorates}
+              sortBy={sortBy}
+              setGovernorates={setGovernorates}
+              setSortBy={setSortBy}
+              resetFilters={resetFilters}
+            />
+          }
         />
         <CustomersGovernorateChips
           counts={governorateCountsData?.counts ?? []}
@@ -87,16 +107,6 @@ export default function CustomersPage() {
           onClear={() => resetFilters()}
         />
       </div>
-
-      <CustomersFilterDrawer
-        open={filterDrawerOpen}
-        onOpenChange={setFilterDrawerOpen}
-        governorates={governorates}
-        sortBy={sortBy}
-        setGovernorates={setGovernorates}
-        setSortBy={setSortBy}
-        resetFilters={resetFilters}
-      />
 
       {isLoading ? (
         <CustomersListSkeleton />

--- a/apps/dashboard/src/app/[lang]/(dashboard)/orders/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/orders/page.tsx
@@ -13,6 +13,7 @@ import {
   EmptyMedia,
 } from "@dukkani/ui/components/empty";
 import { Icons } from "@dukkani/ui/components/icons";
+import { InputGroupButton } from "@dukkani/ui/components/input-group";
 import { useLocale, useTranslations } from "next-intl";
 import { type ReactNode, useState } from "react";
 import { OrdersFilterDrawer } from "@/components/app/orders/orders-filter-drawer";
@@ -111,21 +112,30 @@ export default function OrdersPage() {
         <OrdersSearchBar
           value={search}
           onChange={setSearch}
-          onFilterClick={() => setFilterDrawerOpen(true)}
-          filterActive={filterActive}
+          filterTrigger={
+            <OrdersFilterDrawer
+              trigger={
+                <InputGroupButton
+                  type="button"
+                  variant={filterActive ? "default" : "ghost"}
+                  size="icon-sm"
+                  aria-label={t("filterDrawer.title")}
+                >
+                  <Icons.slidersHorizontal className="size-4" />
+                </InputGroupButton>
+              }
+              open={filterDrawerOpen}
+              onOpenChange={setFilterDrawerOpen}
+              status={status}
+              dateRange={dateRange}
+              setStatus={setStatus}
+              setDateRange={setDateRange}
+              resetFilters={resetFilters}
+            />
+          }
         />
         <OrdersStatusTabs value={status} onChange={setStatus} />
       </div>
-
-      <OrdersFilterDrawer
-        open={filterDrawerOpen}
-        onOpenChange={setFilterDrawerOpen}
-        status={status}
-        dateRange={dateRange}
-        setStatus={setStatus}
-        setDateRange={setDateRange}
-        resetFilters={resetFilters}
-      />
 
       {listBody}
     </div>

--- a/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
@@ -20,6 +20,7 @@ import {
   EmptyMedia,
 } from "@dukkani/ui/components/empty";
 import { Icons } from "@dukkani/ui/components/icons";
+import { InputGroupButton } from "@dukkani/ui/components/input-group";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
@@ -106,28 +107,36 @@ export default function ProductsPage() {
         <ProductsSearchBar
           value={search}
           onChange={setSearch}
-          onFilterClick={() => setFilterDrawerOpen(true)}
-          filterActive={filterActive}
+          filterTrigger={
+            <ProductsFilterDrawer
+              trigger={
+                <InputGroupButton
+                  type="button"
+                  variant={filterActive ? "default" : "ghost"}
+                  size="icon-sm"
+                  aria-label={t("filterDrawer.title")}
+                >
+                  <Icons.slidersHorizontal className="size-4" />
+                </InputGroupButton>
+              }
+              open={filterDrawerOpen}
+              onOpenChange={setFilterDrawerOpen}
+              published={published}
+              stockFilter={stockFilter}
+              variantsFilter={variantsFilter}
+              priceMin={priceMin}
+              priceMax={priceMax}
+              setPublished={setPublished}
+              setStockFilter={setStockFilter}
+              setVariantsFilter={setVariantsFilter}
+              setPriceMin={setPriceMin}
+              setPriceMax={setPriceMax}
+              resetFilters={resetFilters}
+            />
+          }
         />
         <ProductsStatusTabs value={published} onChange={setPublished} />
       </div>
-
-      {/* Filter Drawer */}
-      <ProductsFilterDrawer
-        open={filterDrawerOpen}
-        onOpenChange={setFilterDrawerOpen}
-        published={published}
-        stockFilter={stockFilter}
-        variantsFilter={variantsFilter}
-        priceMin={priceMin}
-        priceMax={priceMax}
-        setPublished={setPublished}
-        setStockFilter={setStockFilter}
-        setVariantsFilter={setVariantsFilter}
-        setPriceMin={setPriceMin}
-        setPriceMax={setPriceMax}
-        resetFilters={resetFilters}
-      />
 
       {/* Product List */}
       {isLoading ? (

--- a/apps/dashboard/src/components/app/customers/customers-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/customers/customers-filter-drawer.tsx
@@ -74,7 +74,7 @@ export function CustomersFilterDrawer({
   return (
     <ResponsivePopover open={open} onOpenChange={onOpenChange}>
       <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
-      <ResponsivePopoverContent className="w-96 max-w-md">
+      <ResponsivePopoverContent className="w-full xl:w-96 xl:max-w-md">
         <div className="flex flex-row items-center justify-between border-b p-4">
           <p className="font-semibold text-foreground">{t("title")}</p>
           <Button

--- a/apps/dashboard/src/components/app/customers/customers-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/customers/customers-filter-drawer.tsx
@@ -1,19 +1,18 @@
 "use client";
 
-import { LIST_GOVERNORATES } from "@dukkani/common/schemas/enums";
 import type { CustomerSort } from "@dukkani/common/schemas/customer/input";
 import type { GovernorateInfer } from "@dukkani/common/schemas/enums";
+import { LIST_GOVERNORATES } from "@dukkani/common/schemas/enums";
 import { Button } from "@dukkani/ui/components/button";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@dukkani/ui/components/drawer";
 import { Label } from "@dukkani/ui/components/label";
 import { RadioGroup, RadioGroupItem } from "@dukkani/ui/components/radio-group";
+import {
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+} from "@dukkani/ui/components/responsive-popover";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 const SORT_OPTIONS: CustomerSort[] = [
@@ -24,6 +23,7 @@ const SORT_OPTIONS: CustomerSort[] = [
 ];
 
 interface CustomersFilterDrawerProps {
+  trigger: ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   governorates: GovernorateInfer[];
@@ -34,6 +34,7 @@ interface CustomersFilterDrawerProps {
 }
 
 export function CustomersFilterDrawer({
+  trigger,
   open,
   onOpenChange,
   governorates,
@@ -71,10 +72,11 @@ export function CustomersFilterDrawer({
   };
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="max-h-[85vh]">
-        <DrawerHeader className="flex flex-row items-center justify-between">
-          <DrawerTitle>{t("title")}</DrawerTitle>
+    <ResponsivePopover open={open} onOpenChange={onOpenChange}>
+      <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+      <ResponsivePopoverContent className="w-96 max-w-md">
+        <div className="flex flex-row items-center justify-between border-b p-4">
+          <p className="font-semibold text-foreground">{t("title")}</p>
           <Button
             variant="ghost"
             size="sm"
@@ -83,9 +85,9 @@ export function CustomersFilterDrawer({
           >
             {t("clearAll")}
           </Button>
-        </DrawerHeader>
+        </div>
 
-        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 pb-4">
+        <div className="flex max-h-[60vh] flex-1 flex-col gap-6 overflow-y-auto px-4 py-4">
           <div className="space-y-2">
             <p className="font-medium text-sm">{t("governorate")}</p>
             <div className="flex flex-wrap gap-2">
@@ -123,10 +125,10 @@ export function CustomersFilterDrawer({
           </div>
         </div>
 
-        <DrawerFooter className="flex flex-row gap-2">
+        <div className="flex flex-row gap-2 border-t p-4">
           <Button onClick={handleApply}>{t("apply")}</Button>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+        </div>
+      </ResponsivePopoverContent>
+    </ResponsivePopover>
   );
 }

--- a/apps/dashboard/src/components/app/customers/customers-search-bar.tsx
+++ b/apps/dashboard/src/components/app/customers/customers-search-bar.tsx
@@ -4,23 +4,22 @@ import { Icons } from "@dukkani/ui/components/icons";
 import {
   InputGroup,
   InputGroupAddon,
-  InputGroupButton,
   InputGroupInput,
 } from "@dukkani/ui/components/input-group";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 
 interface CustomersSearchBarProps {
   value: string;
   onChange: (value: string) => void;
-  onFilterClick?: () => void;
-  filterActive?: boolean;
+  /** The filter trigger + popover/drawer, e.g. `<CustomersFilterDrawer trigger={...} .../>`. */
+  filterTrigger?: ReactNode;
 }
 
 export function CustomersSearchBar({
   value,
   onChange,
-  onFilterClick,
-  filterActive = false,
+  filterTrigger,
 }: CustomersSearchBarProps) {
   const t = useTranslations("customers.list");
 
@@ -36,17 +35,7 @@ export function CustomersSearchBar({
       <InputGroupAddon align="inline-start">
         <Icons.search className="text-muted-foreground" />
       </InputGroupAddon>
-      <InputGroupAddon align="inline-end">
-        <InputGroupButton
-          type="button"
-          variant={filterActive ? "default" : "ghost"}
-          size="icon-sm"
-          onClick={onFilterClick}
-          aria-label={t("filterDrawer.title")}
-        >
-          <Icons.slidersHorizontal className="size-4" />
-        </InputGroupButton>
-      </InputGroupAddon>
+      <InputGroupAddon align="inline-end">{filterTrigger}</InputGroupAddon>
     </InputGroup>
   );
 }

--- a/apps/dashboard/src/components/app/orders/orders-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/orders/orders-filter-drawer.tsx
@@ -7,13 +7,12 @@ import {
 import { Button } from "@dukkani/ui/components/button";
 import { DateRangePicker } from "@dukkani/ui/components/date-range-picker";
 import {
-  Drawer,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@dukkani/ui/components/drawer";
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+} from "@dukkani/ui/components/responsive-popover";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 interface DateRange {
@@ -22,6 +21,7 @@ interface DateRange {
 }
 
 interface OrdersFilterDrawerProps {
+  trigger: ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   status: OrderStatusFilter;
@@ -32,6 +32,7 @@ interface OrdersFilterDrawerProps {
 }
 
 export function OrdersFilterDrawer({
+  trigger,
   open,
   onOpenChange,
   status,
@@ -64,10 +65,11 @@ export function OrdersFilterDrawer({
   };
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="max-h-[85vh]">
-        <DrawerHeader className="flex flex-row items-center justify-between">
-          <DrawerTitle>{t("title")}</DrawerTitle>
+    <ResponsivePopover open={open} onOpenChange={onOpenChange}>
+      <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+      <ResponsivePopoverContent className="w-96 max-w-md">
+        <div className="flex flex-row items-center justify-between border-b p-4">
+          <p className="font-semibold text-foreground">{t("title")}</p>
           <Button
             variant="ghost"
             size="sm"
@@ -76,9 +78,9 @@ export function OrdersFilterDrawer({
           >
             {t("clearAll")}
           </Button>
-        </DrawerHeader>
+        </div>
 
-        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 pb-4">
+        <div className="flex max-h-[60vh] flex-1 flex-col gap-6 overflow-y-auto px-4 py-4">
           {/* Status */}
           <div className="space-y-2">
             <p className="font-medium text-sm">{t("status")}</p>
@@ -111,12 +113,12 @@ export function OrdersFilterDrawer({
           </div>
         </div>
 
-        <DrawerFooter className="flex flex-row gap-2">
+        <div className="flex flex-row gap-2 border-t p-4">
           <Button onClick={handleApply} className="w-full">
             {t("apply")}
           </Button>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+        </div>
+      </ResponsivePopoverContent>
+    </ResponsivePopover>
   );
 }

--- a/apps/dashboard/src/components/app/orders/orders-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/orders/orders-filter-drawer.tsx
@@ -67,7 +67,7 @@ export function OrdersFilterDrawer({
   return (
     <ResponsivePopover open={open} onOpenChange={onOpenChange}>
       <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
-      <ResponsivePopoverContent className="w-96 max-w-md">
+      <ResponsivePopoverContent className="w-full xl:w-96 xl:max-w-md">
         <div className="flex flex-row items-center justify-between border-b p-4">
           <p className="font-semibold text-foreground">{t("title")}</p>
           <Button

--- a/apps/dashboard/src/components/app/orders/orders-search-bar.tsx
+++ b/apps/dashboard/src/components/app/orders/orders-search-bar.tsx
@@ -4,23 +4,22 @@ import { Icons } from "@dukkani/ui/components/icons";
 import {
   InputGroup,
   InputGroupAddon,
-  InputGroupButton,
   InputGroupInput,
 } from "@dukkani/ui/components/input-group";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 
 interface OrdersSearchBarProps {
   value: string;
   onChange: (value: string) => void;
-  onFilterClick?: () => void;
-  filterActive?: boolean;
+  /** The filter trigger + popover/drawer, e.g. `<OrdersFilterDrawer trigger={...} .../>`. */
+  filterTrigger?: ReactNode;
 }
 
 export function OrdersSearchBar({
   value,
   onChange,
-  onFilterClick,
-  filterActive = false,
+  filterTrigger,
 }: OrdersSearchBarProps) {
   const t = useTranslations("orders.list");
 
@@ -36,17 +35,7 @@ export function OrdersSearchBar({
       <InputGroupAddon align="inline-start">
         <Icons.search className="text-muted-foreground" />
       </InputGroupAddon>
-      <InputGroupAddon align="inline-end">
-        <InputGroupButton
-          type="button"
-          variant={filterActive ? "default" : "ghost"}
-          size="icon-sm"
-          onClick={onFilterClick}
-          aria-label={t("filterDrawer.title")}
-        >
-          <Icons.slidersHorizontal className="size-4" />
-        </InputGroupButton>
-      </InputGroupAddon>
+      <InputGroupAddon align="inline-end">{filterTrigger}</InputGroupAddon>
     </InputGroup>
   );
 }

--- a/apps/dashboard/src/components/app/products/category-drawer.tsx
+++ b/apps/dashboard/src/components/app/products/category-drawer.tsx
@@ -2,24 +2,22 @@
 
 import { createCategoryInputSchema } from "@dukkani/common/schemas/category/input";
 import { Button } from "@dukkani/ui/components/button";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@dukkani/ui/components/drawer";
 import { FieldGroup } from "@dukkani/ui/components/field";
 import { Form } from "@dukkani/ui/components/forms/wrapper";
+import {
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+} from "@dukkani/ui/components/responsive-popover";
 import { useAppForm } from "@dukkani/ui/hooks/use-app-form";
 import { useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { appMutations } from "@/shared/api/mutations";
 import { useActiveStoreStore } from "@/shared/lib/store/active.store";
 
 interface CategoryDrawerProps {
+  trigger: ReactNode;
   onCategoryCreated?: (categoryId: string) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -28,6 +26,7 @@ interface CategoryDrawerProps {
 const categoryFormSchema = createCategoryInputSchema.omit({ storeId: true });
 
 export function CategoryDrawer({
+  trigger,
   onCategoryCreated,
   open,
   onOpenChange,
@@ -65,15 +64,18 @@ export function CategoryDrawer({
   });
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle>{t("form.category.create")}</DrawerTitle>
-          <DrawerDescription>
+    <ResponsivePopover open={open} onOpenChange={onOpenChange}>
+      <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+      <ResponsivePopoverContent className="w-96 max-w-md">
+        <div className="flex flex-col gap-0.5 border-b p-4">
+          <p className="font-semibold text-foreground">
+            {t("form.category.create")}
+          </p>
+          <p className="text-muted-foreground text-sm">
             {t("form.category.createDescription")}
-          </DrawerDescription>
-        </DrawerHeader>
-        <div className="px-6">
+          </p>
+        </div>
+        <div className="px-6 py-4">
           <Form onSubmit={form.handleSubmit}>
             <form.AppForm>
               <FieldGroup>
@@ -86,7 +88,7 @@ export function CategoryDrawer({
                   )}
                 </form.AppField>
               </FieldGroup>
-              <DrawerFooter className="px-0">
+              <div className="mt-4 flex flex-col gap-2">
                 <form.Subscribe>
                   {(formState) => (
                     <>
@@ -99,19 +101,21 @@ export function CategoryDrawer({
                       >
                         {t("form.category.create")}
                       </Button>
-                      <DrawerClose asChild>
-                        <Button variant="outline" type="button">
-                          {t("form.cancel")}
-                        </Button>
-                      </DrawerClose>
+                      <Button
+                        variant="outline"
+                        type="button"
+                        onClick={() => onOpenChange(false)}
+                      >
+                        {t("form.cancel")}
+                      </Button>
                     </>
                   )}
                 </form.Subscribe>
-              </DrawerFooter>
+              </div>
             </form.AppForm>
           </Form>
         </div>
-      </DrawerContent>
-    </Drawer>
+      </ResponsivePopoverContent>
+    </ResponsivePopover>
   );
 }

--- a/apps/dashboard/src/components/app/products/category-drawer.tsx
+++ b/apps/dashboard/src/components/app/products/category-drawer.tsx
@@ -66,7 +66,7 @@ export function CategoryDrawer({
   return (
     <ResponsivePopover open={open} onOpenChange={onOpenChange}>
       <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
-      <ResponsivePopoverContent className="w-96 max-w-md">
+      <ResponsivePopoverContent className="w-full xl:w-96 xl:max-w-md">
         <div className="flex flex-col gap-0.5 border-b p-4">
           <p className="font-semibold text-foreground">
             {t("form.category.create")}

--- a/apps/dashboard/src/components/app/products/product-form-essentials.tsx
+++ b/apps/dashboard/src/components/app/products/product-form-essentials.tsx
@@ -4,6 +4,7 @@ import type { SelectOptionGroup } from "@dukkani/ui/components/forms/select-fiel
 import { Skeleton } from "@dukkani/ui/components/skeleton";
 import { withForm } from "@dukkani/ui/hooks/use-app-form";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { handleAPIError } from "@/shared/api/error-handler";
 import { client } from "@/shared/api/orpc";
 import { productFormOptions } from "@/shared/lib/product/form";
@@ -55,14 +56,14 @@ export const ProductFormEssentials = withForm({
   props: {
     storeId: "",
     categoriesOptions: [] as SelectOptionGroup[],
-    onOpenCategoryDrawer: () => {},
+    categoryNewOptionTrigger: null as ReactNode,
     optimizeFiles: async (files: File[]) => files,
   },
   render: function Render({
     form,
     storeId,
     categoriesOptions,
-    onOpenCategoryDrawer,
+    categoryNewOptionTrigger,
     optimizeFiles,
   }) {
     const t = useTranslations("products.create");
@@ -157,7 +158,7 @@ export const ProductFormEssentials = withForm({
               label={t("form.category.label")}
               placeholder={t("form.category.uncategorized")}
               options={categoriesOptions}
-              onNewOptionClick={onOpenCategoryDrawer}
+              newOptionTrigger={categoryNewOptionTrigger}
             />
           )}
         </form.AppField>

--- a/apps/dashboard/src/components/app/products/product-form.tsx
+++ b/apps/dashboard/src/components/app/products/product-form.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Button } from "@dukkani/ui/components/button";
 import { FieldGroup, FieldSet } from "@dukkani/ui/components/field";
 import { Form } from "@dukkani/ui/components/forms/wrapper";
+import { Icons } from "@dukkani/ui/components/icons";
 import { useTranslations } from "next-intl";
 import { forwardRef, useImperativeHandle } from "react";
 import { compressImagesForUpload } from "@/shared/lib/image-compression";
@@ -26,7 +28,6 @@ export const ProductForm = forwardRef<
     categoriesOptions,
     isCategoryDrawerOpen,
     setIsCategoryDrawerOpen,
-    handleOpenCategoryDrawer,
     handleCategoryCreated,
     storeMismatch,
     productQuery,
@@ -60,35 +61,39 @@ export const ProductForm = forwardRef<
   }
 
   return (
-    <>
-      <Form
-        onSubmit={form.handleSubmit}
-        className="flex flex-col gap-4 px-2 pb-24"
-      >
-        <FieldGroup>
-          <FieldSet>
-            <FieldGroup>
-              <form.AppForm>
-                <ProductFormEssentials
-                  form={form}
-                  storeId={storeId}
-                  categoriesOptions={categoriesOptions}
-                  onOpenCategoryDrawer={handleOpenCategoryDrawer}
-                  optimizeFiles={compressImagesForUpload}
-                />
-                <ProductFormVariants form={form} />
-                <ProductFormActions form={form} />
-              </form.AppForm>
-            </FieldGroup>
-          </FieldSet>
-        </FieldGroup>
-      </Form>
-      <CategoryDrawer
-        onCategoryCreated={handleCategoryCreated}
-        open={isCategoryDrawerOpen}
-        onOpenChange={setIsCategoryDrawerOpen}
-      />
-    </>
+    <Form
+      onSubmit={form.handleSubmit}
+      className="flex flex-col gap-4 px-2 pb-24"
+    >
+      <FieldGroup>
+        <FieldSet>
+          <FieldGroup>
+            <form.AppForm>
+              <ProductFormEssentials
+                form={form}
+                storeId={storeId}
+                categoriesOptions={categoriesOptions}
+                categoryNewOptionTrigger={
+                  <CategoryDrawer
+                    trigger={
+                      <Button type="button" variant="outline" size="icon">
+                        <Icons.plus className="size-4" />
+                      </Button>
+                    }
+                    onCategoryCreated={handleCategoryCreated}
+                    open={isCategoryDrawerOpen}
+                    onOpenChange={setIsCategoryDrawerOpen}
+                  />
+                }
+                optimizeFiles={compressImagesForUpload}
+              />
+              <ProductFormVariants form={form} />
+              <ProductFormActions form={form} />
+            </form.AppForm>
+          </FieldGroup>
+        </FieldSet>
+      </FieldGroup>
+    </Form>
   );
 });
 

--- a/apps/dashboard/src/components/app/products/products-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/products/products-filter-drawer.tsx
@@ -11,19 +11,19 @@ import type {
   VariantsFilter,
 } from "@dukkani/common/schemas/product/input";
 import { Button } from "@dukkani/ui/components/button";
-import {
-  Drawer,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@dukkani/ui/components/drawer";
 import { Field, FieldLabel } from "@dukkani/ui/components/field";
 import { Input } from "@dukkani/ui/components/input";
+import {
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+} from "@dukkani/ui/components/responsive-popover";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 interface ProductsFilterDrawerProps {
+  trigger: ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   published: PublishedFilter;
@@ -40,6 +40,7 @@ interface ProductsFilterDrawerProps {
 }
 
 export function ProductsFilterDrawer({
+  trigger,
   open,
   onOpenChange,
   published,
@@ -104,10 +105,11 @@ export function ProductsFilterDrawer({
   };
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="max-h-[85vh]">
-        <DrawerHeader className="flex flex-row items-center justify-between">
-          <DrawerTitle>{t("title")}</DrawerTitle>
+    <ResponsivePopover open={open} onOpenChange={onOpenChange}>
+      <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
+      <ResponsivePopoverContent className="w-96 max-w-md">
+        <div className="flex flex-row items-center justify-between border-b p-4">
+          <p className="font-semibold text-foreground">{t("title")}</p>
           <Button
             variant="ghost"
             size="sm"
@@ -116,9 +118,9 @@ export function ProductsFilterDrawer({
           >
             {t("clearAll")}
           </Button>
-        </DrawerHeader>
+        </div>
 
-        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 pb-4">
+        <div className="flex max-h-[60vh] flex-1 flex-col gap-6 overflow-y-auto px-4 py-4">
           {/* Status */}
           <div className="space-y-2">
             <p className="font-medium text-sm">{t("status")}</p>
@@ -211,12 +213,12 @@ export function ProductsFilterDrawer({
           </div>
         </div>
 
-        <DrawerFooter className="flex flex-row gap-2">
+        <div className="flex flex-row gap-2 border-t p-4">
           <Button onClick={handleApply} className="w-full">
             {t("apply")}
           </Button>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+        </div>
+      </ResponsivePopoverContent>
+    </ResponsivePopover>
   );
 }

--- a/apps/dashboard/src/components/app/products/products-filter-drawer.tsx
+++ b/apps/dashboard/src/components/app/products/products-filter-drawer.tsx
@@ -107,7 +107,7 @@ export function ProductsFilterDrawer({
   return (
     <ResponsivePopover open={open} onOpenChange={onOpenChange}>
       <ResponsivePopoverTrigger asChild>{trigger}</ResponsivePopoverTrigger>
-      <ResponsivePopoverContent className="w-96 max-w-md">
+      <ResponsivePopoverContent className="w-full xl:w-96 xl:max-w-md">
         <div className="flex flex-row items-center justify-between border-b p-4">
           <p className="font-semibold text-foreground">{t("title")}</p>
           <Button

--- a/apps/dashboard/src/components/app/products/products-search-bar.tsx
+++ b/apps/dashboard/src/components/app/products/products-search-bar.tsx
@@ -4,23 +4,22 @@ import { Icons } from "@dukkani/ui/components/icons";
 import {
   InputGroup,
   InputGroupAddon,
-  InputGroupButton,
   InputGroupInput,
 } from "@dukkani/ui/components/input-group";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 
 interface ProductsSearchBarProps {
   value: string;
   onChange: (value: string) => void;
-  onFilterClick?: () => void;
-  filterActive?: boolean;
+  /** The filter trigger + popover/drawer, e.g. `<ProductsFilterDrawer trigger={...} .../>`. */
+  filterTrigger?: ReactNode;
 }
 
 export function ProductsSearchBar({
   value,
   onChange,
-  onFilterClick,
-  filterActive = false,
+  filterTrigger,
 }: ProductsSearchBarProps) {
   const t = useTranslations("products.list");
 
@@ -36,17 +35,7 @@ export function ProductsSearchBar({
       <InputGroupAddon align="inline-start">
         <Icons.search className="text-muted-foreground" />
       </InputGroupAddon>
-      <InputGroupAddon align="inline-end">
-        <InputGroupButton
-          type="button"
-          variant={filterActive ? "default" : "ghost"}
-          size="icon-sm"
-          onClick={onFilterClick}
-          aria-label={t("filterDrawer.title")}
-        >
-          <Icons.slidersHorizontal className="size-4" />
-        </InputGroupButton>
-      </InputGroupAddon>
+      <InputGroupAddon align="inline-end">{filterTrigger}</InputGroupAddon>
     </InputGroup>
   );
 }

--- a/packages/ui/src/components/forms/select-field.tsx
+++ b/packages/ui/src/components/forms/select-field.tsx
@@ -34,6 +34,13 @@ interface SelectFieldProps
   options?: SelectOptionGroup[] | (() => Promise<SelectOptionGroup[]>);
   placeholder?: string;
   onNewOptionClick?: () => void;
+  /**
+   * Renders in place of the default "+" button when provided — use this to
+   * wrap the button in a `ResponsivePopoverTrigger`/`DrawerTrigger` (e.g. a
+   * "create category" popover) instead of a plain `onClick` callback.
+   * Takes precedence over `onNewOptionClick`.
+   */
+  newOptionTrigger?: React.ReactNode;
   noReset?: boolean;
 }
 
@@ -45,6 +52,7 @@ export function SelectField({
   placeholder = "",
   options: optionsOrPromise,
   onNewOptionClick,
+  newOptionTrigger,
   noReset = false,
   ...props
 }: SelectFieldProps) {
@@ -110,16 +118,17 @@ export function SelectField({
           <SelectTrigger aria-invalid={isInvalid} className="grow">
             <SelectValue id={field.name} placeholder={placeholder} />
           </SelectTrigger>
-          {onNewOptionClick && (
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              onClick={onNewOptionClick}
-            >
-              <Icons.plus className="size-4" />
-            </Button>
-          )}
+          {newOptionTrigger ??
+            (onNewOptionClick && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={onNewOptionClick}
+              >
+                <Icons.plus className="size-4" />
+              </Button>
+            ))}
           {!noReset && (
             <Button
               type="button"

--- a/packages/ui/src/components/responsive-popover.tsx
+++ b/packages/ui/src/components/responsive-popover.tsx
@@ -82,6 +82,9 @@ type ResponsivePopoverContentProps = React.ComponentProps<
 function ResponsivePopoverContent({
   className,
   align = "end",
+  side = "bottom",
+  sideOffset = 4,
+  alignOffset = 0,
   children,
   ...props
 }: ResponsivePopoverContentProps) {
@@ -92,6 +95,9 @@ function ResponsivePopoverContent({
       <PopoverContent
         data-slot="responsive-popover-content"
         align={align}
+        side={side}
+        sideOffset={sideOffset}
+        alignOffset={alignOffset}
         className={cn("w-80 max-w-sm p-0", className)}
         {...props}
       >
@@ -104,6 +110,7 @@ function ResponsivePopoverContent({
     <DrawerContent
       data-slot="responsive-popover-content"
       className={cn("max-h-[85vh]", className)}
+      {...props}
     >
       {children}
     </DrawerContent>

--- a/packages/ui/src/components/responsive-popover.tsx
+++ b/packages/ui/src/components/responsive-popover.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import { useIsMobile } from "../hooks/use-mobile";
+import { cn } from "../lib/utils";
+import { Drawer, DrawerContent, DrawerTrigger } from "./drawer";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+/**
+ * Breakpoint at which `ResponsivePopover` switches from a `Drawer` (mobile,
+ * bottom sheet) to a `Popover` (desktop, anchored). Matches the dashboard
+ * shell's always-visible sidebar breakpoint so the two layout switches agree
+ * on what counts as "desktop".
+ */
+const RESPONSIVE_POPOVER_BREAKPOINT = 1280;
+
+const ResponsivePopoverContext = React.createContext<boolean | null>(null);
+
+function useResponsivePopoverContext() {
+  const isDesktop = React.useContext(ResponsivePopoverContext);
+  if (isDesktop === null) {
+    throw new Error(
+      "ResponsivePopover subcomponents must be used within a <ResponsivePopover>",
+    );
+  }
+  return isDesktop;
+}
+
+type ResponsivePopoverProps = React.ComponentProps<typeof Popover>;
+
+/**
+ * Renders a `Popover` at >=1280px and a `Drawer` (bottom sheet) below that,
+ * sharing the exact same trigger/content children between both. Use with
+ * `ResponsivePopoverTrigger` and `ResponsivePopoverContent` — content should
+ * stay breakpoint-agnostic, since only the surrounding container swaps.
+ *
+ * @example
+ * ```tsx
+ * <ResponsivePopover open={open} onOpenChange={setOpen}>
+ *   <ResponsivePopoverTrigger asChild>
+ *     <Button variant="outline">Filters</Button>
+ *   </ResponsivePopoverTrigger>
+ *   <ResponsivePopoverContent>
+ *     {// shared filter body, unchanged between mobile/desktop}
+ *   </ResponsivePopoverContent>
+ * </ResponsivePopover>
+ * ```
+ */
+function ResponsivePopover({ ...props }: ResponsivePopoverProps) {
+  const isMobile = useIsMobile(RESPONSIVE_POPOVER_BREAKPOINT);
+  const isDesktop = !isMobile;
+
+  const Container = isDesktop ? Popover : Drawer;
+
+  return (
+    <ResponsivePopoverContext.Provider value={isDesktop}>
+      <Container {...props} />
+    </ResponsivePopoverContext.Provider>
+  );
+}
+
+type ResponsivePopoverTriggerProps = React.ComponentProps<
+  typeof PopoverTrigger
+>;
+
+function ResponsivePopoverTrigger({ ...props }: ResponsivePopoverTriggerProps) {
+  const isDesktop = useResponsivePopoverContext();
+  const Trigger = isDesktop ? PopoverTrigger : DrawerTrigger;
+
+  return <Trigger data-slot="responsive-popover-trigger" {...props} />;
+}
+
+type ResponsivePopoverContentProps = React.ComponentProps<
+  typeof PopoverContent
+>;
+
+/**
+ * Desktop content is capped to a sane fixed width (unlike the drawer, which
+ * spans the viewport) — pass `className` to override if a filter body needs
+ * more room.
+ */
+function ResponsivePopoverContent({
+  className,
+  align = "end",
+  children,
+  ...props
+}: ResponsivePopoverContentProps) {
+  const isDesktop = useResponsivePopoverContext();
+
+  if (isDesktop) {
+    return (
+      <PopoverContent
+        data-slot="responsive-popover-content"
+        align={align}
+        className={cn("w-80 max-w-sm p-0", className)}
+        {...props}
+      >
+        {children}
+      </PopoverContent>
+    );
+  }
+
+  return (
+    <DrawerContent
+      data-slot="responsive-popover-content"
+      className={cn("max-h-[85vh]", className)}
+    >
+      {children}
+    </DrawerContent>
+  );
+}
+
+export {
+  ResponsivePopover,
+  ResponsivePopoverContent,
+  ResponsivePopoverTrigger,
+};

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -2,20 +2,27 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
-export function useIsMobile() {
+/**
+ * Tracks whether the viewport is narrower than `breakpoint` (defaults to the
+ * standard mobile breakpoint of 768px). Pass a custom breakpoint to reuse the
+ * same matchMedia-based tracking for other container/layout switches (e.g.
+ * `ResponsivePopover` uses 1280px to match the dashboard shell's
+ * always-visible sidebar breakpoint) instead of re-deriving the pattern.
+ */
+export function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
     undefined,
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(window.innerWidth < breakpoint);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(window.innerWidth < breakpoint);
     return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [breakpoint]);
 
   return !!isMobile;
 }

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -17,10 +17,10 @@ export function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT) {
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < breakpoint);
+      setIsMobile(mql.matches);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < breakpoint);
+    setIsMobile(mql.matches);
     return () => mql.removeEventListener("change", onChange);
   }, [breakpoint]);
 


### PR DESCRIPTION
## Summary

Closes #487

Filters (products/orders/customers) and the inline "create category" form always rendered as a bottom-sheet `Drawer`, even on desktop, which is an awkward, mobile-shaped interaction for what should be a lightweight anchored popover.

- Added `ResponsivePopover` / `ResponsivePopoverTrigger` / `ResponsivePopoverContent` in `packages/ui/src/components/responsive-popover.tsx`: renders a `Popover` at `>=1280px` (matching the dashboard shell's always-visible sidebar breakpoint) and a `Drawer` below that. Trigger and content markup is written once and shared between both — only the container swaps.
- Extended `useIsMobile` (`packages/ui/src/hooks/use-mobile.ts`) to accept an optional custom breakpoint (defaults to 768px, unchanged for existing callers) instead of adding a second matchMedia hook for the 1280px case.
- Migrated to `ResponsivePopover`:
  - `apps/dashboard/src/components/app/products/products-filter-drawer.tsx`
  - `apps/dashboard/src/components/app/orders/orders-filter-drawer.tsx`
  - `apps/dashboard/src/components/app/customers/customers-filter-drawer.tsx`
  - `apps/dashboard/src/components/app/products/category-drawer.tsx`
- Left unmigrated: `apps/dashboard/src/components/app/products/products-variant-drawers.tsx` — it's a multi-field variant *editing* surface (stock tracking toggle, price, sku, image picker), not a lightweight selection/filter UI, so per the issue's explicit guidance it stays a plain `Drawer`.
- Updated `.cursor/rules/packages/ui.mdc` to document `ResponsivePopover` and the extended `useIsMobile` breakpoint param.

### Why the trigger prop was needed

Radix `Popover` needs its trigger physically inside the `Popover.Root` tree to anchor correctly — unlike the old Drawer-only pattern where the trigger button lived in a separate search-bar component and the drawer component only rendered content controlled via `open`/`onOpenChange`. To keep the Popover properly anchored without duplicating filter body markup, the 4 migrated components now accept a `trigger` (or `newOptionTrigger` for the category select field) render-prop instead of being purely `open`/`onOpenChange`-controlled with an external trigger. The 3 search-bar components (`products-search-bar.tsx`, `orders-search-bar.tsx`, `customers-search-bar.tsx`) now expose a `filterTrigger` slot that the page composes the filter-drawer-with-trigger into, so the button's visual position inside the search `InputGroup` is unchanged. Filter apply/clear/reset state logic inside each drawer component is untouched.

## Test plan

- [x] `pnpm turbo check-types --filter=@dukkani/dashboard --filter=@dukkani/ui` — passes
- [x] `npx biome check` on all touched files — clean (pre-existing unrelated biome findings elsewhere in the repo left untouched)
- [x] `pnpm turbo build --filter=@dukkani/dashboard` — compiles and typechecks cleanly; fails only at the Next.js env-var validation step (`NEXT_PUBLIC_API_URL`) which is expected/unrelated in this sandbox
- [ ] Manual verification at `>=1280px` (Popover) and `<=768px` (Drawer, unchanged) for products/orders/customers filters and the category create popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)