### PR TITLE
Order detail page: desktop layout (fix header, 2-col grid)

### DIFF
--- a/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { OrderEntity } from "@dukkani/common/entities/order/entity";
+import { Badge } from "@dukkani/ui/components/badge";
 import { cn } from "@dukkani/ui/lib/utils";
 import { notFound, useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -96,63 +97,84 @@ export default function OrderDetailPage() {
     <>
       <div
         className={cn(
-          "container mx-auto max-w-2xl space-y-2 p-3",
+          "container mx-auto max-w-2xl p-3 xl:max-w-6xl",
           showFooter ? "pb-24" : "pb-3",
         )}
       >
-        <OrderDetailHeader title={t("title")} titleClassName="text-base" />
-
-        <OrderDetailSummary
-          badgeVariant={badgeVariant}
-          orderId={order.id}
-          orderMetaLine={formattedDate}
-          statusLabel={tList(statusKey)}
-          totalFormatted={formatPrice(total)}
+        <OrderDetailHeader
+          title={t("title")}
+          titleClassName="text-base"
+          endSlot={
+            <Badge className="hidden xl:inline-flex" variant={badgeVariant}>
+              {tList(statusKey)}
+            </Badge>
+          }
         />
 
-        <OrderDetailMetaCards
-          columnLabels={{ items: t("items"), payment: t("payment") }}
-          itemsLine={t("itemsCount", { count: itemsCount })}
-          paymentLabel={tList(paymentKey)}
-        />
-
-        {order.customer && (
-          <OrderDetailCustomerCard
-            name={order.customer.name}
-            phone={phone}
-            callAriaLabel={callActionLabel}
-            openWhatsAppAriaLabel={t("openWhatsApp")}
-            contactHref={contactHref}
-            isWaLink={isWaLink}
-            isWhatsApp={isWhatsApp}
-            sectionLabel={t("customer")}
+        <div
+          className={cn(
+            "mt-2 space-y-2",
+            "xl:grid xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0",
+            "xl:[grid-template-areas:'summary_summary_customer'_'items_items_delivery'_'items_items_meta']",
+          )}
+        >
+          <OrderDetailSummary
+            badgeVariant={badgeVariant}
+            className="xl:[grid-area:summary]"
+            orderId={order.id}
+            orderMetaLine={formattedDate}
+            statusLabel={tList(statusKey)}
+            totalFormatted={formatPrice(total)}
           />
-        )}
 
-        {order.address && (
-          <OrderDetailDeliveryCard
-            city={order.address.city}
-            labels={{ deliveryAddress: t("deliveryAddress") }}
-            notes={order.notes}
-            postalCode={order.address.postalCode}
-            street={order.address.street}
+          <OrderDetailMetaCards
+            className="xl:[grid-area:meta]"
+            columnLabels={{ items: t("items"), payment: t("payment") }}
+            itemsLine={t("itemsCount", { count: itemsCount })}
+            paymentLabel={tList(paymentKey)}
           />
-        )}
 
-        <OrderDetailItemsCard
-          deliveryFee={deliveryFee}
-          formatPrice={formatPrice}
-          itemCountLine={(n) => t("itemsCount", { count: n })}
-          labels={{
-            delivery: t("delivery"),
-            orderItems: t("orderItems"),
-            subtotal: t("subtotal"),
-            total: t("total"),
-          }}
-          orderItems={order.orderItems}
-          subtotal={subtotal}
-          total={total}
-        />
+          {order.customer && (
+            <OrderDetailCustomerCard
+              callAriaLabel={callActionLabel}
+              className="xl:[grid-area:customer]"
+              contactHref={contactHref}
+              isWaLink={isWaLink}
+              isWhatsApp={isWhatsApp}
+              name={order.customer.name}
+              openWhatsAppAriaLabel={t("openWhatsApp")}
+              phone={phone}
+              sectionLabel={t("customer")}
+            />
+          )}
+
+          {order.address && (
+            <OrderDetailDeliveryCard
+              city={order.address.city}
+              className="xl:[grid-area:delivery]"
+              labels={{ deliveryAddress: t("deliveryAddress") }}
+              notes={order.notes}
+              postalCode={order.address.postalCode}
+              street={order.address.street}
+            />
+          )}
+
+          <OrderDetailItemsCard
+            className="xl:[grid-area:items]"
+            deliveryFee={deliveryFee}
+            formatPrice={formatPrice}
+            itemCountLine={(n) => t("itemsCount", { count: n })}
+            labels={{
+              delivery: t("delivery"),
+              orderItems: t("orderItems"),
+              subtotal: t("subtotal"),
+              total: t("total"),
+            }}
+            orderItems={order.orderItems}
+            subtotal={subtotal}
+            total={total}
+          />
+        </div>
       </div>
 
       {showFooter && (

--- a/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -115,12 +115,11 @@ export default function OrderDetailPage() {
           className={cn(
             "mt-2 space-y-2",
             "xl:grid xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0",
-            "xl:[grid-template-areas:'summary_summary_customer'_'items_items_delivery'_'items_items_meta']",
           )}
         >
           <OrderDetailSummary
             badgeVariant={badgeVariant}
-            className="xl:[grid-area:summary]"
+            className="xl:order-1 xl:col-span-2"
             orderId={order.id}
             orderMetaLine={formattedDate}
             statusLabel={tList(statusKey)}
@@ -128,7 +127,7 @@ export default function OrderDetailPage() {
           />
 
           <OrderDetailMetaCards
-            className="xl:[grid-area:meta]"
+            className="xl:order-4 xl:col-span-1 xl:col-start-3"
             columnLabels={{ items: t("items"), payment: t("payment") }}
             itemsLine={t("itemsCount", { count: itemsCount })}
             paymentLabel={tList(paymentKey)}
@@ -137,7 +136,7 @@ export default function OrderDetailPage() {
           {order.customer && (
             <OrderDetailCustomerCard
               callAriaLabel={callActionLabel}
-              className="xl:[grid-area:customer]"
+              className="xl:order-2 xl:col-span-1 xl:col-start-3"
               contactHref={contactHref}
               isWaLink={isWaLink}
               isWhatsApp={isWhatsApp}
@@ -151,7 +150,7 @@ export default function OrderDetailPage() {
           {order.address && (
             <OrderDetailDeliveryCard
               city={order.address.city}
-              className="xl:[grid-area:delivery]"
+              className="xl:order-3 xl:col-span-1 xl:col-start-3"
               labels={{ deliveryAddress: t("deliveryAddress") }}
               notes={order.notes}
               postalCode={order.address.postalCode}
@@ -160,7 +159,7 @@ export default function OrderDetailPage() {
           )}
 
           <OrderDetailItemsCard
-            className="xl:[grid-area:items]"
+            className="xl:order-5 xl:col-span-2 xl:col-start-1 xl:row-span-2"
             deliveryFee={deliveryFee}
             formatPrice={formatPrice}
             itemCountLine={(n) => t("itemsCount", { count: n })}

--- a/apps/dashboard/src/components/app/orders/order-detail-customer-card.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-customer-card.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@dukkani/ui/components/button";
 import { Card } from "@dukkani/ui/components/card";
 import { Icons } from "@dukkani/ui/components/icons";
+import { cn } from "@dukkani/ui/lib/utils";
 import Link from "next/link";
 
 export function OrderDetailCustomerCard({
@@ -12,6 +13,7 @@ export function OrderDetailCustomerCard({
   callAriaLabel,
   openWhatsAppAriaLabel,
   sectionLabel,
+  className,
 }: {
   name: string;
   phone: string | undefined;
@@ -21,9 +23,10 @@ export function OrderDetailCustomerCard({
   callAriaLabel: string;
   openWhatsAppAriaLabel: string;
   sectionLabel: string;
+  className?: string;
 }) {
   return (
-    <Card className="gap-0 py-0 shadow-sm">
+    <Card className={cn("gap-0 py-0 shadow-sm", className)}>
       <div className="p-3">
         <p className="mb-1.5 font-medium text-muted-foreground text-xs">
           {sectionLabel}

--- a/apps/dashboard/src/components/app/orders/order-detail-delivery-card.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-delivery-card.tsx
@@ -1,6 +1,7 @@
 import { AddressEntity } from "@dukkani/common/entities/address/entity";
 import { Card } from "@dukkani/ui/components/card";
 import { Icons } from "@dukkani/ui/components/icons";
+import { cn } from "@dukkani/ui/lib/utils";
 
 export function OrderDetailDeliveryCard({
   city,
@@ -8,12 +9,14 @@ export function OrderDetailDeliveryCard({
   street,
   notes,
   labels,
+  className,
 }: {
   city: string;
   postalCode: string | null | undefined;
   street: string;
   notes: string | null | undefined;
   labels: { deliveryAddress: string };
+  className?: string;
 }) {
   const headline =
     AddressEntity.formatOrderListLocation({
@@ -21,7 +24,7 @@ export function OrderDetailDeliveryCard({
       postalCode: postalCode ?? null,
     }) ?? city;
   return (
-    <Card className="gap-0 py-0 shadow-sm">
+    <Card className={cn("gap-0 py-0 shadow-sm", className)}>
       <div className="space-y-1.5 p-3">
         <p className="font-medium text-muted-foreground text-xs">
           {labels.deliveryAddress}

--- a/apps/dashboard/src/components/app/orders/order-detail-error-state.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-error-state.tsx
@@ -10,7 +10,7 @@ export function OrderDetailErrorState({
   errorMessage: string;
 }) {
   return (
-    <div className="container mx-auto max-w-2xl p-4">
+    <div className="container mx-auto max-w-2xl p-4 xl:max-w-6xl">
       <div className="mb-4">
         <OrderDetailHeader title={title} />
       </div>

--- a/apps/dashboard/src/components/app/orders/order-detail-header.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-header.tsx
@@ -34,9 +34,7 @@ export function OrderDetailHeader({
           {title}
         </h1>
       </div>
-      {endSlot ? (
-        <div className="flex shrink-0 items-center gap-2">{endSlot}</div>
-      ) : null}
+      {endSlot}
     </div>
   );
 }

--- a/apps/dashboard/src/components/app/orders/order-detail-header.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-header.tsx
@@ -5,26 +5,38 @@ import { Icons } from "@dukkani/ui/components/icons";
 import { cn } from "@dukkani/ui/lib/utils";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 import { RoutePaths } from "@/shared/config/routes";
 
 export function OrderDetailHeader({
   title,
   titleClassName,
+  endSlot,
 }: {
   title: string;
   titleClassName?: string;
+  endSlot?: ReactNode;
 }) {
   const t = useTranslations("orders.detail");
 
   return (
-    <div className="flex items-center justify-between">
-      <Button variant="ghost" size="icon" asChild>
-        <Link href={RoutePaths.ORDERS.INDEX.url} aria-label={t("backToOrders")}>
-          <Icons.arrowLeft className="size-4" />
-        </Link>
-      </Button>
-      <h1 className={cn("font-semibold", titleClassName)}>{title}</h1>
-      <div className="w-9" />
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center gap-1">
+        <Button variant="ghost" size="icon" asChild className="shrink-0">
+          <Link
+            href={RoutePaths.ORDERS.INDEX.url}
+            aria-label={t("backToOrders")}
+          >
+            <Icons.arrowLeft className="size-4" />
+          </Link>
+        </Button>
+        <h1 className={cn("truncate font-semibold", titleClassName)}>
+          {title}
+        </h1>
+      </div>
+      {endSlot ? (
+        <div className="flex shrink-0 items-center gap-2">{endSlot}</div>
+      ) : null}
     </div>
   );
 }

--- a/apps/dashboard/src/components/app/orders/order-detail-items-card.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-items-card.tsx
@@ -1,8 +1,9 @@
 import type { OrderIncludeOutput } from "@dukkani/common/schemas/order/output";
 import { Card } from "@dukkani/ui/components/card";
-import Image from "next/image";
 import { Icons } from "@dukkani/ui/components/icons";
 import { Separator } from "@dukkani/ui/components/separator";
+import { cn } from "@dukkani/ui/lib/utils";
+import Image from "next/image";
 
 type LineItem = NonNullable<OrderIncludeOutput["orderItems"]>[number];
 
@@ -14,6 +15,7 @@ export function OrderDetailItemsCard({
   formatPrice,
   labels,
   itemCountLine,
+  className,
 }: {
   orderItems: LineItem[] | undefined;
   subtotal: number;
@@ -27,9 +29,10 @@ export function OrderDetailItemsCard({
     total: string;
   };
   itemCountLine: (quantity: number) => string;
+  className?: string;
 }) {
   return (
-    <Card className="gap-0 py-0 shadow-sm">
+    <Card className={cn("gap-0 py-0 shadow-sm", className)}>
       <div className="p-3">
         <p className="mb-1.5 font-medium text-muted-foreground text-xs">
           {labels.orderItems}

--- a/apps/dashboard/src/components/app/orders/order-detail-meta-cards.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-meta-cards.tsx
@@ -1,17 +1,20 @@
 import { Card } from "@dukkani/ui/components/card";
 import { Icons } from "@dukkani/ui/components/icons";
+import { cn } from "@dukkani/ui/lib/utils";
 
 export function OrderDetailMetaCards({
   paymentLabel,
   itemsLine,
   columnLabels,
+  className,
 }: {
   paymentLabel: string;
   itemsLine: string;
   columnLabels: { payment: string; items: string };
+  className?: string;
 }) {
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className={cn("grid grid-cols-2 gap-2", className)}>
       <Card className="gap-0 py-0 shadow-sm">
         <div className="flex items-center gap-2.5 p-3">
           <Icons.payments className="size-4 shrink-0 text-muted-foreground" />

--- a/apps/dashboard/src/components/app/orders/order-detail-skeleton.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-skeleton.tsx
@@ -21,7 +21,7 @@ export function OrderDetailSkeleton() {
           )}
         >
           <div className="flex flex-col items-center gap-0.5 py-6 xl:[grid-area:summary]">
-            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-6 w-24 rounded-full xl:hidden" />
             <Skeleton className="h-10 w-40" />
             <Skeleton className="mt-1 h-3 w-48" />
           </div>

--- a/apps/dashboard/src/components/app/orders/order-detail-skeleton.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-skeleton.tsx
@@ -1,87 +1,98 @@
 import { Skeleton } from "@dukkani/ui/components/skeleton";
+import { cn } from "@dukkani/ui/lib/utils";
 
 export function OrderDetailSkeleton() {
   return (
     <>
-      <div className="container mx-auto max-w-2xl space-y-2 p-3 pb-24">
-        <div className="flex items-center justify-between">
-          <Skeleton className="size-9 rounded-md" />
-          <Skeleton className="h-5 w-28" />
-          <div className="w-9" />
+      <div className="container mx-auto max-w-2xl p-3 pb-24 xl:max-w-6xl">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            <Skeleton className="size-9 rounded-md" />
+            <Skeleton className="h-5 w-28" />
+          </div>
+          <Skeleton className="hidden h-6 w-20 rounded-full xl:block" />
         </div>
 
-        <div className="flex flex-col items-center gap-0.5 pt-0">
-          <Skeleton className="h-6 w-24 rounded-full" />
-          <Skeleton className="h-10 w-40" />
-          <Skeleton className="mt-1 h-3 w-48" />
-        </div>
+        <div
+          className={cn(
+            "mt-2 space-y-2",
+            "xl:grid xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0",
+            "xl:[grid-template-areas:'summary_summary_customer'_'items_items_delivery'_'items_items_meta']",
+          )}
+        >
+          <div className="flex flex-col items-center gap-0.5 py-6 xl:[grid-area:summary]">
+            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-10 w-40" />
+            <Skeleton className="mt-1 h-3 w-48" />
+          </div>
 
-        <div className="grid grid-cols-2 gap-2">
-          <div className="flex items-center gap-2.5 rounded-xl border bg-card p-3 shadow-sm">
-            <Skeleton className="size-4 shrink-0" />
-            <div className="space-y-1">
-              <Skeleton className="h-2.5 w-12" />
-              <Skeleton className="h-4 w-20" />
+          <div className="grid grid-cols-2 gap-2 xl:[grid-area:meta]">
+            <div className="flex items-center gap-2.5 rounded-xl border bg-card p-3 shadow-sm">
+              <Skeleton className="size-4 shrink-0" />
+              <div className="space-y-1">
+                <Skeleton className="h-2.5 w-12" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            </div>
+            <div className="flex items-center gap-2.5 rounded-xl border bg-card p-3 shadow-sm">
+              <Skeleton className="size-4 shrink-0" />
+              <div className="space-y-1">
+                <Skeleton className="h-2.5 w-10" />
+                <Skeleton className="h-4 w-16" />
+              </div>
             </div>
           </div>
-          <div className="flex items-center gap-2.5 rounded-xl border bg-card p-3 shadow-sm">
-            <Skeleton className="size-4 shrink-0" />
-            <div className="space-y-1">
-              <Skeleton className="h-2.5 w-10" />
-              <Skeleton className="h-4 w-16" />
+
+          <div className="rounded-xl border bg-card p-3 shadow-sm xl:[grid-area:customer]">
+            <Skeleton className="mb-1.5 h-2.5 w-16" />
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+              </div>
+              <Skeleton className="size-8 shrink-0 rounded-md" />
             </div>
           </div>
-        </div>
 
-        <div className="rounded-xl border bg-card p-3 shadow-sm">
-          <Skeleton className="mb-1.5 h-2.5 w-16" />
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2.5">
-              <Skeleton className="size-8 shrink-0 rounded-full" />
+          <div className="space-y-1.5 rounded-xl border bg-card p-3 shadow-sm xl:[grid-area:delivery]">
+            <Skeleton className="h-2.5 w-28" />
+            <div className="flex gap-2">
+              <Skeleton className="mt-0.5 size-4 shrink-0" />
               <div className="space-y-1.5">
                 <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-48" />
               </div>
             </div>
-            <Skeleton className="size-8 shrink-0 rounded-md" />
           </div>
-        </div>
 
-        <div className="space-y-1.5 rounded-xl border bg-card p-3 shadow-sm">
-          <Skeleton className="h-2.5 w-28" />
-          <div className="flex gap-2">
-            <Skeleton className="mt-0.5 size-4 shrink-0" />
-            <div className="space-y-1.5">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-3 w-48" />
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-xl border bg-card p-3 shadow-sm">
-          <Skeleton className="mb-1.5 h-2.5 w-20" />
-          {Array.from({ length: 2 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-2 py-2 first:pt-0">
-              <Skeleton className="size-10 shrink-0 rounded-lg" />
-              <div className="flex-1 space-y-1.5">
-                <Skeleton className="h-4 w-36" />
-                <Skeleton className="h-3 w-12" />
+          <div className="rounded-xl border bg-card p-3 shadow-sm xl:[grid-area:items]">
+            <Skeleton className="mb-1.5 h-2.5 w-20" />
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2 py-2 first:pt-0">
+                <Skeleton className="size-10 shrink-0 rounded-lg" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-36" />
+                  <Skeleton className="h-3 w-12" />
+                </div>
+                <Skeleton className="h-4 w-14" />
               </div>
-              <Skeleton className="h-4 w-14" />
-            </div>
-          ))}
-          <div className="mt-2 space-y-1.5 border-border border-t border-dashed pt-2">
-            <div className="flex justify-between">
-              <Skeleton className="h-3 w-16" />
-              <Skeleton className="h-3 w-20" />
-            </div>
-            <div className="flex justify-between">
-              <Skeleton className="h-3 w-16" />
-              <Skeleton className="h-3 w-20" />
-            </div>
-            <div className="flex justify-between">
-              <Skeleton className="h-4 w-10" />
-              <Skeleton className="h-4 w-20" />
+            ))}
+            <div className="mt-2 space-y-1.5 border-border border-t border-dashed pt-2">
+              <div className="flex justify-between">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+              <div className="flex justify-between">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+              <div className="flex justify-between">
+                <Skeleton className="h-4 w-10" />
+                <Skeleton className="h-4 w-20" />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/dashboard/src/components/app/orders/order-detail-summary.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-summary.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@dukkani/ui/components/badge";
+import { cn } from "@dukkani/ui/lib/utils";
 import type { ComponentProps } from "react";
 
 export function OrderDetailSummary({
@@ -7,15 +8,17 @@ export function OrderDetailSummary({
   orderId,
   orderMetaLine,
   badgeVariant,
+  className,
 }: {
   statusLabel: string;
   totalFormatted: string;
   orderId: string;
   orderMetaLine: string;
   badgeVariant: NonNullable<ComponentProps<typeof Badge>["variant"]>;
+  className?: string;
 }) {
   return (
-    <div className="flex flex-col items-center gap-0.5 py-6">
+    <div className={cn("flex flex-col items-center gap-0.5 py-6", className)}>
       <Badge variant={badgeVariant}>{statusLabel}</Badge>
       <p className="font-bold text-4xl tracking-tight">{totalFormatted}</p>
       <p className="mt-1 text-muted-foreground text-xs">

--- a/apps/dashboard/src/components/app/orders/order-detail-summary.tsx
+++ b/apps/dashboard/src/components/app/orders/order-detail-summary.tsx
@@ -19,7 +19,9 @@ export function OrderDetailSummary({
 }) {
   return (
     <div className={cn("flex flex-col items-center gap-0.5 py-6", className)}>
-      <Badge variant={badgeVariant}>{statusLabel}</Badge>
+      <Badge className="xl:hidden" variant={badgeVariant}>
+        {statusLabel}
+      </Badge>
       <p className="font-bold text-4xl tracking-tight">{totalFormatted}</p>
       <p className="mt-1 text-muted-foreground text-xs">
         #{orderId} · {orderMetaLine}


### PR DESCRIPTION
## Summary

- Fixes the confirmed header bug in `order-detail-header.tsx`: removes the `w-9` spacer div that fake-centered the title by balancing the back button's width. Replaced with a normal left-aligned flex header — back button + title on the left, with an optional `endSlot` (right side) used to surface the status badge at `xl:` (>=1280px). This applies at **all** breakpoints since the bug wasn't breakpoint-gated.
- At `>=1280px`, the order detail body now uses a CSS grid with named `grid-template-areas` (main column ~2/3: summary + items card; sidebar column ~1/3: customer card, delivery card, meta cards), similar to Shopify-style order detail pages.
- Below `1280px`, layout is visually unchanged — the grid-area placement only activates at `xl:`, so single-column stacking order (summary, meta, customer, delivery, items) is preserved exactly via the existing DOM order.
- `order-detail-skeleton.tsx` and `order-detail-error-state.tsx` updated to mirror the same header fix and grid shape so there's no layout jump when data resolves.
- Threaded an optional `className` prop through `order-detail-summary.tsx`, `order-detail-meta-cards.tsx`, `order-detail-customer-card.tsx`, `order-detail-delivery-card.tsx`, and `order-detail-items-card.tsx` so the page can assign each card to its grid area without changing their internal layout.
- `order-detail-footer.tsx` intentionally left unchanged — it already works correctly at every breakpoint (fixed, full-width, no centering hack), so moving its mutation-triggering actions into the header was left out of scope to avoid introducing duplicate action surfaces for status changes.

Closes #491

## Test plan

- [x] `pnpm turbo check-types --filter=@dukkani/dashboard --filter=@dukkani/ui` passes
- [x] `npx biome check` clean on all touched files
- [x] `pnpm turbo build --filter=@dukkani/dashboard` compiles/typechecks successfully (fails later only on missing `NEXT_PUBLIC_API_URL` env var in this sandbox, unrelated to this change)
- [ ] Manual verification at 375px/768px/1280px/1440px in a running dev server (not run in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order detail pages now display the current order status prominently in the header on larger screens.
  * Order detail content uses a responsive grid layout for improved organization on wide screens.
  * Long order titles are truncated cleanly to preserve header layout.

* **Style**
  * Improved responsive spacing, card placement, loading skeletons, and error-state width across order details.
  * Order detail cards now adapt more consistently to different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->