### PR TITLE
fix: add dense grid packing to order detail sidebar layout

### DIFF
--- a/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx
@@ -114,7 +114,7 @@ export default function OrderDetailPage() {
         <div
           className={cn(
             "mt-2 space-y-2",
-            "xl:grid xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0",
+            "xl:grid xl:grid-flow-row-dense xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0",
           )}
         >
           <OrderDetailSummary


### PR DESCRIPTION
## Summary

Addresses a coderabbitai review finding from #502 (merged) that wasn't resolved before merge.

The desktop order-detail grid in `apps/dashboard/src/app/[lang]/(dashboard)/orders/[id]/page.tsx` uses `xl:order-N` / `xl:col-span` / `xl:col-start-3` for auto-placement across the sidebar cards (summary, meta cards, customer, delivery, items). When `order.customer` or `order.address` is missing (guest checkout / pickup orders), the corresponding sidebar card isn't rendered, and without `grid-auto-flow: dense` the CSS Grid auto-placement algorithm only moves forward — it pushes the `OrderDetailItemsCard` (order-5, col-start-1, col-span-2, row-span-2) down to a new row instead of backfilling the now-empty column 1-2 cells, leaving a visible gap.

- Added `xl:grid-flow-row-dense` to the grid container's className (alongside the existing `xl:grid xl:grid-cols-3 xl:items-start xl:gap-4 xl:space-y-0` utilities), matching the fix coderabbitai suggested on the original PR.
- Class order adjusted per this repo's Tailwind class-sorting lint (`biome`'s `useSortedClasses`).

Dense packing only affects which row auto-placed items land in — it does not override any explicit `col-start`/`col-span`/`row-span` value, so the main items card's 2/3-column, 2-row sizing is unaffected in both the full (customer + delivery present) and partial (one or both missing) cases.

## Test plan
- [x] `npx biome check` on the touched file — clean (after sorting classes as flagged)
- [x] `pnpm turbo check-types --filter=@dukkani/dashboard --filter=@dukkani/ui` — passes
- [x] `pnpm turbo build --filter=@dukkani/dashboard` — fails late on missing `NEXT_PUBLIC_API_URL` env var, unrelated to this change (expected in this environment)
- [ ] Manual visual check on staging: order detail page for a guest-checkout order at `xl` breakpoint, confirm no gap next to the items card

🤖 Generated with [Claude Code](https://claude.com/claude-code)