### PR TITLE
fix: CI workflow Node version mismatch causing silent cleanup-preview failures

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Context

While investigating why `dukkani-api` preview deployments kept failing with a Neon "Resource provisioning failed" error across several open PRs, I found the actual root cause: `.github/workflows/cleanup-preview.yml` (which deletes each PR's Neon preview branch and R2 objects on close) has been silently failing on every single PR.

`package.json` pins `packageManager: pnpm@11.10.0`, which requires Node >=22.13. But `cleanup-preview.yml`, `prisma-migrate.yml`, and `ci-failure-analysis.yml` all pin `actions/setup-node` to Node `"20"`. Once that step switches the active Node to 20, its pnpm-aware cache resolution invokes the pinned pnpm 11.10.0 binary, which crashes:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
warn: This version of pnpm requires at least Node.js v22.13
```

In `cleanup-preview.yml` specifically, the `Install dependencies` and R2-cleanup steps have no `if: always()`, so they were silently skipped whenever this happened. Only the Neon branch-deletion step (which has `if: always()` + `continue-on-error: true`) still ran — but the overall job was still reported as **failed** due to the earlier step, even when the Neon deletion itself may have succeeded. Either way, this has been the CI-visible symptom of the underlying Neon capacity issue reported on several dashboard-responsive-design PRs (#503, #505, #506, #507).

## Fix

Bump `node-version` from `"20"` to `"22"` in all three affected workflows so they match what the repo's own pinned pnpm version requires.

## Test plan
- [ ] Confirm `cleanup-preview` job succeeds end-to-end on the next PR close (Setup Node.js no longer crashes, R2 + Neon cleanup steps both run)
- [ ] Confirm `prisma-migrate` and `ci-failure-analysis` workflows still run correctly on Node 22

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use Node.js 22 instead of Node.js 20.
  * This applies to CI analysis, preview cleanup, and database migration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->