### PR TITLE
fix: add chevron indicator to sidebar Create menu

### DIFF
--- a/apps/dashboard/src/components/layout/nav-create-action.tsx
+++ b/apps/dashboard/src/components/layout/nav-create-action.tsx
@@ -38,6 +38,7 @@ export function NavCreateAction() {
             >
               <Icons.plus />
               <span>{t("create")}</span>
+              <Icons.chevronDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent


### PR DESCRIPTION
## Summary
- The "+ Create" sidebar button already had a label and opened a dropdown (New product / New customer), but read as an opaque single-action button rather than a menu.
- Added a trailing chevron-down indicator (hidden when the sidebar is collapsed to icon-only, same as the label).
- No behavior change — purely a discoverability fix per the issue's scope.

Closes #526

## Test plan
- [x] `tsc --noEmit` passes for apps/dashboard
- [ ] Verify chevron shows in expanded sidebar, hides when collapsed to icons, and existing New product/New customer options still work