### PR TITLE
fix: remove redundant "stock: " label prefix from products list

### DIFF
--- a/packages/common/src/locale/dashboard/ar.json
+++ b/packages/common/src/locale/dashboard/ar.json
@@ -472,7 +472,7 @@
       },
       "stockInfo": "المخزون: {count} وحدة • {variants} متغيرات",
       "stockInfoNoVariants": "المخزون: {count} وحدة • لا توجد متغيرات",
-      "stockCount": "المخزون: {count} وحدة",
+      "stockCount": "{count} وحدة",
       "inStock": "متوفر في المخزون",
       "variantCount": "• {variants} متغيرات",
       "noVariants": "• لا توجد متغيرات",

--- a/packages/common/src/locale/dashboard/en.json
+++ b/packages/common/src/locale/dashboard/en.json
@@ -472,7 +472,7 @@
       },
       "stockInfo": "Stock: {count} units • {variants} variants",
       "stockInfoNoVariants": "Stock: {count} units • No variants",
-      "stockCount": "Stock: {count} units",
+      "stockCount": "{count} units",
       "inStock": "In stock",
       "variantCount": "• {variants} variants",
       "noVariants": "• No variants",

--- a/packages/common/src/locale/dashboard/fr.json
+++ b/packages/common/src/locale/dashboard/fr.json
@@ -476,7 +476,7 @@
       },
       "stockInfo": "Stock : {count} unités • {variants} variantes",
       "stockInfoNoVariants": "Stock : {count} unités • Pas de variantes",
-      "stockCount": "Stock : {count} unités",
+      "stockCount": "{count} unités",
       "inStock": "En stock",
       "variantCount": "• {variants} variantes",
       "noVariants": "• Pas de variantes",


### PR DESCRIPTION
## Summary
- Dropped the redundant "stock: " / "Stock : " / "المخزون: " prefix from the `stockCount` translation string in en/fr/ar — the products table column context already makes clear it's a stock figure.
- `inStock`/`outOfStock` strings are unaffected, as scoped.

Closes #530

## Test plan
- [ ] Verify products list/mobile card stock cell reads "X units" (no prefix) in all three locales