### PR TITLE
fix: move add-product action to header on desktop, hide FAB there

### DIFF
--- a/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
@@ -102,7 +102,16 @@ export default function ProductsPage() {
 
   return (
     <div className="container mx-auto max-w-7xl p-4 pb-24 md:p-6 md:pb-8">
-      <ProductsPageHeader />
+      <ProductsPageHeader
+        action={
+          <Button asChild>
+            <Link href={RoutePaths.PRODUCTS.NEW.url}>
+              <Icons.plus className="size-4" />
+              {t("addProduct")}
+            </Link>
+          </Button>
+        }
+      />
 
       {/* Search & Filters */}
       <div className="mb-6 space-y-4">
@@ -180,11 +189,11 @@ export default function ProductsPage() {
         </Empty>
       )}
 
-      {/* FAB - Add Product */}
+      {/* FAB - Add Product: mobile/tablet only, the header action covers desktop */}
       <Button
         asChild
         size="icon-lg"
-        className="fixed end-4 bottom-24 z-50 size-14 rounded-full shadow-lg md:end-6 md:bottom-8"
+        className="fixed end-4 bottom-24 z-50 size-14 rounded-full shadow-lg md:end-6 md:bottom-8 xl:hidden"
         aria-label={t("addProduct")}
       >
         <Link href={RoutePaths.PRODUCTS.NEW.url}>

--- a/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
+++ b/apps/dashboard/src/app/[lang]/(dashboard)/products/page.tsx
@@ -104,7 +104,7 @@ export default function ProductsPage() {
     <div className="container mx-auto max-w-7xl p-4 pb-24 md:p-6 md:pb-8">
       <ProductsPageHeader
         action={
-          <Button asChild>
+          <Button asChild className="hidden xl:inline-flex">
             <Link href={RoutePaths.PRODUCTS.NEW.url}>
               <Icons.plus className="size-4" />
               {t("addProduct")}

--- a/apps/dashboard/src/components/app/products/products-page-header.tsx
+++ b/apps/dashboard/src/components/app/products/products-page-header.tsx
@@ -1,16 +1,25 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
 
-export function ProductsPageHeader() {
+interface ProductsPageHeaderProps {
+  /** Desktop-only action rendered next to the heading (e.g. "Add product"). */
+  action?: ReactNode;
+}
+
+export function ProductsPageHeader({ action }: ProductsPageHeaderProps) {
   const t = useTranslations("products.list");
 
   return (
-    <div className="mb-6">
-      <h1 className="font-bold text-2xl md:text-3xl">{t("title")}</h1>
-      <p className="mt-2 text-muted-foreground text-sm md:text-base">
-        {t("description")}
-      </p>
+    <div className="mb-6 flex items-start justify-between gap-4">
+      <div>
+        <h1 className="font-bold text-2xl md:text-3xl">{t("title")}</h1>
+        <p className="mt-2 text-muted-foreground text-sm md:text-base">
+          {t("description")}
+        </p>
+      </div>
+      {action && <div className="hidden shrink-0 xl:block">{action}</div>}
     </div>
   );
 }

--- a/apps/dashboard/src/components/app/products/products-page-header.tsx
+++ b/apps/dashboard/src/components/app/products/products-page-header.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
 interface ProductsPageHeaderProps {
-  /** Desktop-only action rendered next to the heading (e.g. "Add product"). */
+  /** Action rendered next to the heading — the caller controls its own responsive visibility (e.g. "Add product", desktop-only). */
   action?: ReactNode;
 }
 
@@ -19,7 +19,7 @@ export function ProductsPageHeader({ action }: ProductsPageHeaderProps) {
           {t("description")}
         </p>
       </div>
-      {action && <div className="hidden shrink-0 xl:block">{action}</div>}
+      {action && <div className="shrink-0">{action}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `ProductsPageHeader` gains an optional `action` slot rendered next to the heading, `xl:`-only.
- Products page now passes an "Add product" button into that slot.
- The floating action button is now `xl:hidden` instead of just being repositioned at every breakpoint — kept fully functional on mobile/tablet.
- Both entry points link to the same `RoutePaths.PRODUCTS.NEW.url` — no behavior change.

Closes #533

## Test plan
- [x] `tsc --noEmit` passes for apps/dashboard
- [ ] Verify: desktop shows "Add product" next to the heading and no FAB; mobile/tablet keeps the FAB exactly as before; both navigate to the same route