### PR TITLE
fix: review follow-ups for #547, #549, #552 (already merged)

### DIFF
--- a/apps/dashboard/src/components/layout/nav-create-action.tsx
+++ b/apps/dashboard/src/components/layout/nav-create-action.tsx
@@ -38,7 +38,7 @@ export function NavCreateAction() {
             >
               <Icons.plus />
               <span>{t("create")}</span>
-              <Icons.chevronDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
+              <Icons.chevronDown className="ms-auto size-4 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/apps/dashboard/src/components/shared/store-link.tsx
+++ b/apps/dashboard/src/components/shared/store-link.tsx
@@ -25,6 +25,11 @@ export function StoreLink({
     copy(url, "Link copied to clipboard!");
   };
 
+  // Defensive: callers are expected to pass an absolute URL (getStoreUrl()
+  // always includes a protocol today), but a bare domain here would silently
+  // become a relative path when used as an <a href>.
+  const href = /^https?:\/\//.test(url) ? url : `https://${url}`;
+
   return (
     <div className={cn("space-y-2", className)}>
       <Label htmlFor="store-link" className="text-muted-foreground text-sm">
@@ -56,7 +61,7 @@ export function StoreLink({
           aria-label="Open store in new tab"
           asChild
         >
-          <a href={url} target="_blank" rel="noopener noreferrer">
+          <a href={href} target="_blank" rel="noopener noreferrer">
             <Icons.externalLink className="size-4 text-muted-foreground" />
           </a>
         </Button>

--- a/packages/common/src/locale/dashboard/ar.json
+++ b/packages/common/src/locale/dashboard/ar.json
@@ -472,7 +472,7 @@
       },
       "stockInfo": "المخزون: {count} وحدة • {variants} متغيرات",
       "stockInfoNoVariants": "المخزون: {count} وحدة • لا توجد متغيرات",
-      "stockCount": "{count} وحدة",
+      "stockCount": "{count, plural, one {وحدة واحدة} two {وحدتان} few {# وحدات} many {# وحدة} other {# وحدة}}",
       "inStock": "متوفر في المخزون",
       "variantCount": "• {variants} متغيرات",
       "noVariants": "• لا توجد متغيرات",

--- a/packages/common/src/locale/dashboard/en.json
+++ b/packages/common/src/locale/dashboard/en.json
@@ -472,7 +472,7 @@
       },
       "stockInfo": "Stock: {count} units • {variants} variants",
       "stockInfoNoVariants": "Stock: {count} units • No variants",
-      "stockCount": "{count} units",
+      "stockCount": "{count, plural, one {# unit} other {# units}}",
       "inStock": "In stock",
       "variantCount": "• {variants} variants",
       "noVariants": "• No variants",

--- a/packages/common/src/locale/dashboard/fr.json
+++ b/packages/common/src/locale/dashboard/fr.json
@@ -476,7 +476,7 @@
       },
       "stockInfo": "Stock : {count} unités • {variants} variantes",
       "stockInfoNoVariants": "Stock : {count} unités • Pas de variantes",
-      "stockCount": "{count} unités",
+      "stockCount": "{count, plural, one {# unité} other {# unités}}",
       "inStock": "En stock",
       "variantCount": "• {variants} variantes",
       "noVariants": "• Pas de variantes",


### PR DESCRIPTION
## Summary
Small fixes addressing `gemini-code-assist` review feedback on three PRs from the dashboard UX batch that were already merged before I got to their reviews:

- **#547** (`StoreLink`): normalize `url` to an absolute `https://` href defensively. The current (only) caller, `getStoreUrl()`, always returns an absolute URL, so this isn't a live bug — but `StoreLink` is a reusable component, and a future caller passing a bare domain would silently produce a relative-path `href`.
- **#549** (`nav-create-action.tsx`): `ml-auto` → `ms-auto` on the Create menu's chevron so it respects RTL layout (the app supports Arabic).
- **#552** (`stockCount`): switched to ICU `plural` rules (en/fr/ar) instead of a fixed "units" string, so a stock count of 1 reads correctly instead of "1 units".

## Test plan
- [x] `tsc --noEmit` passes for apps/dashboard
- [ ] Verify: store link still opens correctly in a new tab; Create menu chevron sits on the correct side in Arabic; stock count reads correctly for 1 vs many