### PR TITLE
docs: refresh stale .cursor/rules and require keeping them updated

### DIFF
--- a/.cursor/rules/00-project-overview.mdc
+++ b/.cursor/rules/00-project-overview.mdc
@@ -67,6 +67,10 @@ Both `apps/dashboard` and `apps/storefront` follow **Feature Sliced Design (FSD)
 
 Do not add `hooks/api/`, `lib/`, or `stores/` top-level directories to these apps; place new code in the appropriate `shared/` sub-layer instead.
 
+## Maintaining these rules
+
+`.cursor/rules/*.mdc` is the single source of truth referenced by `CLAUDE.md` — stale rules that contradict the code are worse than no rules, since agents trust them over re-deriving the pattern from scratch. When a change introduces or changes a pattern worth reusing (a new shared constant/convention, a non-obvious config requirement, a changed package API shape), update the relevant `.mdc` file **in the same PR**, not as separate follow-up work. Skip it only for one-off, page-specific code that isn't a reusable pattern.
+
 ## Conventions
 
 - Use package imports with the `@dukkani/*` namespace.

--- a/.cursor/rules/apps/dashboard.mdc
+++ b/.cursor/rules/apps/dashboard.mdc
@@ -263,8 +263,29 @@ import { RoutePaths } from "@/shared/config/routes";
 import { getLocale } from "@/shared/config/i18n";
 
 // UI constants
-import { STORE_HEADER_HEIGHT } from "@/shared/config/constants";
+import { layoutConstants } from "@/shared/config/constants";
 ```
+
+### Sticky list-page header pattern
+
+Products/customers/orders list pages wrap their search bar + filter tabs in a sticky container that sits flush under the topbar (which is a flex sibling above the scroll area, not an overlay — see the comment on `layoutConstants` in `constants.ts`):
+
+```tsx
+<div
+  className={cn(
+    "sticky z-10 mb-6 space-y-4 bg-background/95 py-2",
+    layoutConstants.TOPBAR_STICKY_OFFSET_CLASS,
+  )}
+>
+  {/* search bar, status tabs, filter chips */}
+</div>
+```
+
+If the topbar ever becomes an overlay (`position: fixed`/`sticky` itself) instead of a flex sibling, update `layoutConstants.TOPBAR_STICKY_OFFSET_CLASS` in one place rather than every list page.
+
+### Storefront preview links
+
+`getStoreUrl`/`getProductPreviewUrl` (`shared/lib/store/url.util.ts`) build the storefront URL for a store/product — subdomain-based in production, `?store=<slug>` query param in preview/dev (since preview deployments don't have real subdomains). Used by the product edit page's preview pane and the products-list row's "Preview in storefront" quick action; both require `product.published` and an `activeStore` resolved from `appQueries.store.all()`.
 
 ## Providers
 
@@ -398,6 +419,10 @@ const mutation = useMutation(
   })
 );
 ```
+
+## Deployment (`next.config.ts`)
+
+`serverExternalPackages: ["sharp"]` and an `outputFileTracingIncludes` block force-including the pnpm content-addressable `@img/sharp-linux-x64`/`@img/sharp-libvips-linux-x64` binaries are **required**, not optional — without them Next's built-in image optimizer `dlopen`s a native libvips binary that Vercel's output-file tracing otherwise drops from the deployed function, crashing with `ERR_DLOPEN_FAILED` in production. Do not remove this config as "unused"; see #561/#562.
 
 ## Best Practices
 

--- a/.cursor/rules/apps/storefront.mdc
+++ b/.cursor/rules/apps/storefront.mdc
@@ -142,6 +142,10 @@ import { useEnrichedCart } from "@/shared/lib/cart/enricher.hook";
 - Do not inline generic error toasts; keep error mapping centralized.
 - `appMutations` factories automatically wire `onError` to `handleAPIError` — your `onError` callback chains after it, not instead of it.
 
+## Deployment (`next.config.ts`)
+
+`serverExternalPackages: ["sharp"]` and an `outputFileTracingIncludes` block force-including the pnpm content-addressable `@img/sharp-linux-x64`/`@img/sharp-libvips-linux-x64` binaries are **required**, not optional — without them Next's built-in image optimizer `dlopen`s a native libvips binary that Vercel's output-file tracing otherwise drops from the deployed function, crashing with `ERR_DLOPEN_FAILED` in production. Do not remove this config as "unused"; see #561/#562.
+
 ## Best Practices
 
 - Use server components by default and opt into `"use client"` only when needed.

--- a/.cursor/rules/packages/auth.mdc
+++ b/.cursor/rules/packages/auth.mdc
@@ -9,7 +9,8 @@ The `auth` package contains Better Auth configuration and authentication logic. 
 ```
 packages/auth/src/
 ├── env.ts         # Auth environment variables
-└── index.ts       # Auth instance export
+├── utils.ts       # buildTrustedOrigins, deriveCookieDomain, verifyPassword
+└── index.ts       # createAuth factory + auth singleton
 ```
 
 ## Auth Configuration
@@ -19,39 +20,71 @@ packages/auth/src/
 
 ### Pattern
 
-Better Auth is configured with Prisma adapter, email/password authentication, and social providers.
+Auth is built via a `createAuth(database, envConfig)` **factory function**, not a static export — this avoids a circular dependency between `@dukkani/auth` and `@dukkani/db`. The server package calls `initializeAuth()` once at startup to populate the `auth` singleton; everywhere else imports `auth` directly from `@dukkani/auth`.
 
 ```typescript
-import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
-import { database } from "@dukkani/db";
+export function createAuth(
+  database: PrismaClient,
+  envConfig: typeof env,
+): ReturnType<typeof betterAuth<BetterAuthOptions>> {
+  const trustedOrigins = buildTrustedOrigins(/* ... */);
 
-export const auth = betterAuth({
-  database: prismaAdapter(database, {
-    provider: "postgresql",
-  }),
-  secret: env.BETTER_AUTH_SECRET,
-  trustedOrigins: [env.NEXT_PUBLIC_API_URL],
-  emailAndPassword: {
-    enabled: true,
-    password: {
-      hash: hashPassword,
-      verify: verifyPassword,
+  const isProduction =
+    !!envConfig.VERCEL || envConfig.NEXT_PUBLIC_API_URL.startsWith("https://");
+
+  // Dashboard and API run on different subdomains of the same base domain.
+  // Share the session cookie across them via `crossSubDomainCookies`, or the
+  // dashboard's own SSR never sees the cookie the API set.
+  const cookieDomain = isProduction
+    ? deriveCookieDomain(envConfig.NEXT_PUBLIC_API_URL)
+    : undefined;
+
+  return betterAuth<BetterAuthOptions>({
+    database: prismaAdapter(database, { provider: "postgresql" }),
+    secret: envConfig.BETTER_AUTH_SECRET,
+    baseURL: envConfig.NEXT_PUBLIC_API_URL,
+    trustedOrigins,
+    advanced: {
+      useSecureCookies: isProduction,
+      crossSubDomainCookies: cookieDomain
+        ? { enabled: true, domain: cookieDomain }
+        : { enabled: false },
+      cookies: {
+        session_token: { attributes: { sameSite: "lax", httpOnly: true } },
+      },
     },
-  },
-  socialProviders: {
-    facebook: {
-      clientId: env.FACEBOOK_CLIENT_ID,
-      clientSecret: env.FACEBOOK_CLIENT_SECRET,
+    session: {
+      // Trusts a short-lived signed cookie between DB checks, avoiding a
+      // round trip on every oRPC request. No impersonation/ban/role flow
+      // here depends on sub-5-minute session freshness.
+      cookieCache: { enabled: true, maxAge: 5 * 60 },
     },
-    google: {
-      clientId: env.GOOGLE_CLIENT_ID,
-      clientSecret: env.GOOGLE_CLIENT_SECRET,
+    emailAndPassword: {
+      enabled: true,
+      password: { hash: hashPassword, verify: verifyPassword },
     },
-  },
-  plugins: [nextCookies()],
-});
+    socialProviders: {
+      facebook: { clientId: envConfig.FACEBOOK_CLIENT_ID, clientSecret: envConfig.FACEBOOK_CLIENT_SECRET },
+      google: { clientId: envConfig.GOOGLE_CLIENT_ID, clientSecret: envConfig.GOOGLE_CLIENT_SECRET },
+      apple: { clientId: envConfig.APPLE_CLIENT_ID, clientSecret: envConfig.APPLE_CLIENT_SECRET },
+    },
+    plugins: [nextCookies(), openAPI(), lastLoginMethod()],
+  });
+}
+
+export let auth: ReturnType<typeof betterAuth<BetterAuthOptions>>;
+
+export function initializeAuth(
+  database: PrismaClient,
+  envConfig: Parameters<typeof createAuth>[1],
+): void {
+  auth = createAuth(database, envConfig);
+}
 ```
+
+### Cross-subdomain cookie sharing
+
+`deriveCookieDomain` (in `utils.ts`) parses the API's hostname and returns a leading-dot shared domain (e.g. `.dukkani.co`) so the session cookie set by the API is readable by the dashboard's own server on a sibling subdomain. Without this, the dashboard's SSR never sees the session cookie and every load falls through to a client-side check racing the redirect-to-login logic. Only applied in production/Vercel — local dev stays on the default host-only cookie.
 
 ## Password Hashing
 
@@ -80,11 +113,12 @@ async function verifyPassword({
 ### Required Variables
 
 - `BETTER_AUTH_SECRET` - Secret for session encryption
-- `NEXT_PUBLIC_API_URL` - Allowed CORS origin
-- `FACEBOOK_CLIENT_ID` - Facebook OAuth client ID (optional)
-- `FACEBOOK_CLIENT_SECRET` - Facebook OAuth client secret (optional)
-- `GOOGLE_CLIENT_ID` - Google OAuth client ID (optional)
-- `GOOGLE_CLIENT_SECRET` - Google OAuth client secret (optional)
+- `NEXT_PUBLIC_API_URL` - Allowed CORS origin; also the source hostname for `deriveCookieDomain`
+- `NEXT_PUBLIC_DASHBOARD_URL` - Added to `trustedOrigins`
+- `NEXT_PUBLIC_ALLOWED_ORIGIN`, `CORS_PREVIEW_ORIGIN_PATTERN` - Extra origins passed to `buildTrustedOrigins` (e.g. Vercel preview URL patterns)
+- `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` - Facebook OAuth (optional)
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` - Google OAuth (optional)
+- `APPLE_CLIENT_ID` / `APPLE_CLIENT_SECRET` - Apple OAuth (optional)
 
 ## Usage
 
@@ -114,7 +148,9 @@ export const authClient = createAuthClient({
 
 ### Main Export
 `packages/auth/src/index.ts` exports:
-- `auth` - Better Auth instance
+- `auth` - Better Auth instance (singleton, populated by `initializeAuth()` at server startup — do not read it before init runs)
+- `createAuth` - Factory used by `initializeAuth`; call directly only in tests/tooling that need their own instance
+- `initializeAuth` - Called once by the server package's init module
 
 ### Usage
 


### PR DESCRIPTION
Closes #568

## Summary

- Rewrite `packages/auth.mdc` to match the actual `createAuth`/`initializeAuth` factory pattern in `packages/auth/src/index.ts` — the doc previously described a static `betterAuth({...})` export that hasn't existed for a while. Adds coverage for cross-subdomain cookie sharing (`crossSubDomainCookies`, `deriveCookieDomain`), the session `cookieCache`, the `apple` social provider, and the `openAPI`/`lastLoginMethod` plugins.
- Document the sticky list-header pattern (`layoutConstants.TOPBAR_STICKY_OFFSET_CLASS`) in `apps/dashboard.mdc`.
- Document the storefront preview-link helpers (`getStoreUrl`/`getProductPreviewUrl`) in `apps/dashboard.mdc`.
- Document the required `serverExternalPackages`/`outputFileTracingIncludes` sharp/libvips fix in both `apps/dashboard.mdc` and `apps/storefront.mdc`, so it isn't mistaken for dead config later (see #561/#562).
- Add a standing rule in `00-project-overview.mdc`: new reusable patterns get their `.mdc` file updated in the same PR that introduces them, not as separate follow-up work.

## Test plan

- [x] Docs-only change; no code paths affected.
- [x] Cross-checked every documented pattern against the current code (`packages/auth/src/index.ts`, `apps/dashboard/src/shared/config/constants.ts`, `apps/dashboard/src/shared/lib/store/url.util.ts`, `apps/dashboard/next.config.ts`, `apps/storefront/next.config.ts`) before writing it up.