### PR TITLE
fix: never share session cookie across a public-suffix domain

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -39,6 +39,20 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_API_URL: apiUrl,
   },
+  // Proxy the whole API surface through the dashboard's own origin so the
+  // browser only ever talks to one domain. Without this, the session cookie
+  // the API sets is only shareable with the dashboard via a cookie `Domain`
+  // spanning both hosts' shared apex — which doesn't exist on preview
+  // (each app gets its own sibling *.vercel.app alias, not a subdomain of a
+  // common apex), so the cookie never reaches the dashboard's own requests
+  // and every load bounces back to /login. Proxying makes the cookie
+  // first-party to the dashboard in every environment. See #572.
+  rewrites: async () => [
+    {
+      source: "/api/:path*",
+      destination: `${apiUrl}/api/:path*`,
+    },
+  ],
   images: {
     dangerouslyAllowLocalIP: true,
     remotePatterns: [

--- a/apps/dashboard/src/shared/api/auth-client.ts
+++ b/apps/dashboard/src/shared/api/auth-client.ts
@@ -1,14 +1,16 @@
 import type { auth } from "@dukkani/auth";
-import { getApiUrl } from "@dukkani/env/get-api-url";
 import {
   inferAdditionalFields,
   lastLoginMethodClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
-import { env } from "@/env";
 
+// No baseURL: defaults to a same-origin relative "/api/auth", proxied to
+// the real API by the rewrite in next.config.ts. This makes the session
+// cookie first-party to the dashboard's own domain in every environment —
+// see the rewrite comment for why that matters. Don't point this at the
+// API's absolute URL again.
 export const authClient = createAuthClient({
-  baseURL: getApiUrl(env.NEXT_PUBLIC_API_URL),
   plugins: [inferAdditionalFields<typeof auth>(), lastLoginMethodClient()],
 });
 

--- a/apps/dashboard/src/shared/api/orpc.ts
+++ b/apps/dashboard/src/shared/api/orpc.ts
@@ -16,9 +16,16 @@ let orpcClient: DashboardScopedUtils | null = null;
 
 function getORPCClient(): DashboardScopedUtils {
   if (!orpcClient) {
-    const { queryClient, client, orpc } = createORPCClientUtils<AppRouter>(
-      getApiUrl(env.NEXT_PUBLIC_API_URL),
-    );
+    // Browser: relative "" (-> "/api") so requests go through the
+    // dashboard's own origin, proxied to the API by the rewrite in
+    // next.config.ts — keeps the session cookie first-party. See #572.
+    // Server: absolute API URL, since Node's fetch can't resolve a
+    // relative URL and this path already forwards the incoming request's
+    // cookies itself (see the `headers()` option in createORPCClientUtils).
+    const apiUrl =
+      typeof window === "undefined" ? getApiUrl(env.NEXT_PUBLIC_API_URL) : "";
+    const { queryClient, client, orpc } =
+      createORPCClientUtils<AppRouter>(apiUrl);
     orpcClient = {
       queryClient,
       client: client.dashboard as DashboardRouterClient,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -105,7 +105,10 @@ export function createAuth(
         clientSecret: envConfig.APPLE_CLIENT_SECRET,
       },
     },
-    plugins: [nextCookies(), openAPI(), lastLoginMethod()],
+    // nextCookies() must be last: it forwards pending Set-Cookie headers to
+    // Next's cookie store, so any plugin after it whose hooks also set
+    // cookies (e.g. lastLoginMethod) would have theirs silently dropped.
+    plugins: [openAPI(), lastLoginMethod(), nextCookies()],
   });
 }
 

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -50,10 +50,21 @@ export async function verifyPassword({
  * `.preview.dukkani.co`). Returns undefined when there's no subdomain to
  * strip (e.g. localhost, or an apex domain), in which case cross-subdomain
  * cookie sharing should stay disabled.
+ *
+ * Also returns undefined for `*.vercel.app` hosts: `vercel.app` is on the
+ * Public Suffix List, so a `Domain=.vercel.app` cookie is silently rejected
+ * by the browser — and it wouldn't help anyway, since each app's Vercel
+ * git-branch preview alias (`dukkani-api-git-<branch>-<team>.vercel.app` vs
+ * `dukkani-dashboard-git-<branch>-<team>.vercel.app`) is a sibling domain,
+ * not a subdomain of a shared apex. See #517/#538.
  */
 export function deriveCookieDomain(apiUrl: string): string | undefined {
   try {
-    const labels = new URL(apiUrl).hostname.split(".");
+    const hostname = new URL(apiUrl).hostname;
+    if (hostname === "vercel.app" || hostname.endsWith(".vercel.app")) {
+      return undefined;
+    }
+    const labels = hostname.split(".");
     if (labels.length < 3) {
       return undefined;
     }


### PR DESCRIPTION
Closes #572

## What's actually going on

Signing in on a preview deployment succeeds against the API, but the app never redirects to the dashboard — it bounces back to `/login`, including with the demo account prefilled by #559.

`deriveCookieDomain()` (from #538) shares the session cookie across dashboard/API subdomains via `Domain=.<apex>`. That's correct in production (`api.dukkani.co` → `.dukkani.co`, a normal registrable domain). In **preview**, `NEXT_PUBLIC_API_URL` resolves to Vercel's own git-branch alias — confirmed straight from this repo's PR deployment comments: `dukkani-api-git-<branch>-<team>.vercel.app` vs `dukkani-dashboard-git-<branch>-<team>.vercel.app`. These are **sibling** domains, not subdomains of a shared apex — there is no `Domain` value that could ever let a cookie cross between them. `deriveCookieDomain` was computing `.vercel.app`, which is on the Public Suffix List, so the browser silently rejected the cookie outright.

Also fixed a real (separate, smaller) bug surfaced by Better Auth's own runtime warning: `nextCookies()` plugin must be last in the plugins array, or cookies set by plugins registered after it (`lastLoginMethod`) never get forwarded to Next's cookie store.

## Fix

**Commit 1** — `deriveCookieDomain` now returns `undefined` for any `*.vercel.app` hostname (stops emitting a cookie the browser would reject anyway), and fixed the plugin order. This alone doesn't restore login on preview, since there's no shared apex domain to share a cookie across in the first place.

**Commit 2** — the actual fix: proxy the dashboard's entire `/api/*` surface through its own origin via a `next.config.ts` rewrite to the real API, and point browser-side calls (`authClient`, the client-side oRPC link) at the resulting same-origin relative path instead of the API's absolute URL. The session cookie the API sets now arrives as a plain first-party cookie on the dashboard's own domain — in every environment, no shared-apex domain or `crossSubDomainCookies` needed at all for this to work. Server-side calls (SSR prefetch, `getServerSession`) keep hitting the API's absolute URL directly — they already forward the incoming request's cookies via `headers()`, and Node's `fetch` can't resolve a relative URL anyway.

## Test plan

- [x] `pnpm turbo run check-types` — all packages pass.
- [x] `apps/dashboard`: clean `next build` (Turbopack, matching prod); `routes-manifest.json` shows the `/api/:path*` rewrite registered correctly.
- [ ] Needs a real preview deployment to confirm login now redirects to the dashboard.