### PR TITLE
fix: RPCLink/better-fetch crash from relative baseURL — regression in #573, breaks login for everyone on main right now

### DIFF
--- a/apps/dashboard/src/shared/api/auth-client.ts
+++ b/apps/dashboard/src/shared/api/auth-client.ts
@@ -5,12 +5,18 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
-// No baseURL: defaults to a same-origin relative "/api/auth", proxied to
-// the real API by the rewrite in next.config.ts. This makes the session
-// cookie first-party to the dashboard's own domain in every environment —
-// see the rewrite comment for why that matters. Don't point this at the
-// API's absolute URL again.
+// baseURL is the page's own origin, so requests go through the dashboard's
+// own domain, proxied to the API by the rewrite in next.config.ts — keeps
+// the session cookie first-party. See #572. Better Auth's underlying fetch
+// does `new URL(url, baseURL)`, which requires baseURL to be an absolute
+// URL (a relative one throws), so this can't just be omitted/relative.
+// `window` is undefined during this module's server-side evaluation (this
+// file is only ever imported from "use client" components, so the actual
+// browser bundle re-evaluates it fresh with `window` defined before any
+// request is made) — undefined here just falls back to Better Auth's own
+// default resolution, which is never actually used to fetch anything.
 export const authClient = createAuthClient({
+  baseURL: typeof window === "undefined" ? undefined : window.location.origin,
   plugins: [inferAdditionalFields<typeof auth>(), lastLoginMethodClient()],
 });
 

--- a/apps/dashboard/src/shared/api/orpc.ts
+++ b/apps/dashboard/src/shared/api/orpc.ts
@@ -16,14 +16,18 @@ let orpcClient: DashboardScopedUtils | null = null;
 
 function getORPCClient(): DashboardScopedUtils {
   if (!orpcClient) {
-    // Browser: relative "" (-> "/api") so requests go through the
-    // dashboard's own origin, proxied to the API by the rewrite in
+    // Browser: the page's own origin, so requests go through the
+    // dashboard's own domain, proxied to the API by the rewrite in
     // next.config.ts — keeps the session cookie first-party. See #572.
+    // (RPCLink does `new URL(baseUrl)` internally with no base argument,
+    // so this has to be an absolute URL — a relative "" throws.)
     // Server: absolute API URL, since Node's fetch can't resolve a
-    // relative URL and this path already forwards the incoming request's
-    // cookies itself (see the `headers()` option in createORPCClientUtils).
+    // relative URL either, and this path already forwards the incoming
+    // request's cookies itself (see the `headers()` option below).
     const apiUrl =
-      typeof window === "undefined" ? getApiUrl(env.NEXT_PUBLIC_API_URL) : "";
+      typeof window === "undefined"
+        ? getApiUrl(env.NEXT_PUBLIC_API_URL)
+        : window.location.origin;
     const { queryClient, client, orpc } =
       createORPCClientUtils<AppRouter>(apiUrl);
     orpcClient = {


### PR DESCRIPTION
## This is urgent — main is currently broken

#573 (the same-origin-proxy fix for preview login) was merged into \`main\` and is now live on every branch built off it, including yours. It broke login/email-check entirely, everywhere (not just preview) — matches exactly what you just reported:

\`\`\`
TypeError: Failed to construct 'URL': Invalid URL
    at q.encode (...)
\`\`\`

## Root cause

#573 pointed browser-side requests (\`authClient\`, the oRPC \`client\`) at a relative same-origin path so they'd flow through the dashboard's \`/api/*\` rewrite proxy. Both \`@orpc/client\`'s \`RPCLink\` and Better Auth's underlying \`@better-fetch/fetch\` construct the request URL via \`new URL(url, baseURL)\` — and per the URL spec, \`baseURL\` itself must be an **absolute** URL for that to succeed. A bare relative string (or empty string, what I'd used for the oRPC client) throws immediately, on the very first request — which is exactly the email-existence check fired by clicking "Continue" on the login form.

## Fix

Use \`window.location.origin\` instead of a relative string in both \`orpc.ts\` and \`auth-client.ts\`:
- It's absolute, so URL construction succeeds.
- It's still same-origin, so the \`/api/*\` rewrite from #573 still proxies it to the real API — the whole point of that fix is preserved.
- Guarded for this module's SSR-time evaluation (\`window\` is undefined there, but that server-side instance is never used to actually fetch — the browser re-evaluates the module fresh after hydration, where \`window\` is defined).

## Test plan

- [x] \`pnpm turbo run check-types\` — all packages pass.
- [x] \`apps/dashboard\`: clean \`next build\` (Turbopack, matching prod).
- [ ] Needs a real deployment to confirm the login form's email-check no longer throws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication and API connectivity across browser and server environments.
  * Fixed issues with requests requiring absolute service URLs, helping prevent failures during navigation and server-side rendering.
  * Preserved existing authentication error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->