### PR TITLE
fix: drop crossSubDomainCookies, rely entirely on the API proxy

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,7 +5,7 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import { lastLoginMethod, openAPI } from "better-auth/plugins";
 import type { env } from "./env";
-import { buildTrustedOrigins, deriveCookieDomain, verifyPassword } from "./utils";
+import { buildTrustedOrigins, verifyPassword } from "./utils";
 
 /**
  * Factory function to create a Better Auth instance
@@ -33,24 +33,23 @@ export function createAuth(
     envConfig.CORS_PREVIEW_ORIGIN_PATTERN,
   );
 
-  // Determine if we need production-grade cookie settings (secure cookies,
-  // shared across the dashboard/API subdomains).
+  // Determine if we need production-grade cookie settings (secure cookies).
   const isVercel = !!envConfig.VERCEL;
   const isProduction =
     isVercel || envConfig.NEXT_PUBLIC_API_URL.startsWith("https://");
 
-  // The dashboard and API run on different subdomains of the same base
-  // domain (e.g. api.dukkani.co / dashboard.dukkani.co, or
-  // api.preview.dukkani.co / dashboard.preview.dukkani.co in preview).
-  // Without a shared cookie Domain, the session cookie is host-only to the
-  // API's origin and the browser never attaches it when the dashboard's own
-  // server renders a page — every dashboard load then falls through to a
-  // client-side session check that races the redirect-to-login logic. See
-  // github.com/FindMalek/dukkani/issues/517.
-  const cookieDomain = isProduction
-    ? deriveCookieDomain(envConfig.NEXT_PUBLIC_API_URL)
-    : undefined;
-
+  // We don't attempt to share the session cookie across the dashboard/API
+  // via a cookie `Domain` (crossSubDomainCookies) — dashboard and API are
+  // separate Vercel projects, so their preview URLs are sibling
+  // *.vercel.app aliases with no shared apex to set a Domain on (and it's
+  // not just preview: this app's own NEXT_PUBLIC_API_URL is a static env
+  // var, not resolved per-deployment, so a computed Domain can silently be
+  // wrong in any environment — see #572/#574). Cookies are host-only
+  // instead: apps/dashboard proxies its whole /api/* surface through its
+  // own origin (next.config.ts rewrite), so the browser only ever talks to
+  // one domain and the cookie is naturally first-party there. This is the
+  // pattern Better Auth's own docs/community recommend for split
+  // frontend/backend deployments. See github.com/FindMalek/dukkani/issues/517.
   return betterAuth<BetterAuthOptions>({
     database: prismaAdapter(database, {
       provider: "postgresql",
@@ -60,14 +59,9 @@ export function createAuth(
     trustedOrigins,
     advanced: {
       useSecureCookies: isProduction,
-      crossSubDomainCookies: cookieDomain
-        ? { enabled: true, domain: cookieDomain }
-        : { enabled: false },
       cookies: {
         session_token: {
           attributes: {
-            // Same-site once the cookie is shared across subdomains via
-            // `crossSubDomainCookies` above — no longer need SameSite=None.
             sameSite: "lax",
             httpOnly: true,
           },

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -43,38 +43,6 @@ export async function verifyPassword({
 }
 
 /**
- * Derive the cookie `Domain` attribute that lets the session cookie be shared
- * across all subdomains of the API's own domain (e.g. `api.dukkani.co` and
- * `dashboard.dukkani.co` both sit under `.dukkani.co`; in preview,
- * `api.preview.dukkani.co` and `dashboard.preview.dukkani.co` both sit under
- * `.preview.dukkani.co`). Returns undefined when there's no subdomain to
- * strip (e.g. localhost, or an apex domain), in which case cross-subdomain
- * cookie sharing should stay disabled.
- *
- * Also returns undefined for `*.vercel.app` hosts: `vercel.app` is on the
- * Public Suffix List, so a `Domain=.vercel.app` cookie is silently rejected
- * by the browser — and it wouldn't help anyway, since each app's Vercel
- * git-branch preview alias (`dukkani-api-git-<branch>-<team>.vercel.app` vs
- * `dukkani-dashboard-git-<branch>-<team>.vercel.app`) is a sibling domain,
- * not a subdomain of a shared apex. See #517/#538.
- */
-export function deriveCookieDomain(apiUrl: string): string | undefined {
-  try {
-    const hostname = new URL(apiUrl).hostname;
-    if (hostname === "vercel.app" || hostname.endsWith(".vercel.app")) {
-      return undefined;
-    }
-    const labels = hostname.split(".");
-    if (labels.length < 3) {
-      return undefined;
-    }
-    return `.${labels.slice(1).join(".")}`;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
  * Build trusted origins configuration for Better Auth
  * Returns either a static array or a dynamic function that validates origins
  */


### PR DESCRIPTION
Closes #575

## Pinpointed root cause

The API is issuing `Set-Cookie: ...; Domain=.dukkani.co` (production apex) on every deployment, including preview — confirmed directly from a live captured response on PR #558's preview and cross-checked against Vercel's own deployment record (`target: null`, no custom domain, alias is a raw `dukkani-dashboard-git-...vercel.app`). A browser cannot accept a cookie's `Domain` unless it matches the responding host or is a real parent of it, so this gets silently rejected — the request-side proxy from #573/#574 was already correct, but it can't fix a *response* naming the wrong cookie domain.

Cause: `deriveCookieDomain(envConfig.NEXT_PUBLIC_API_URL)` reads the **API app's own** env var, which — unlike dashboard/storefront — has no per-deployment resolution logic in `apps/api/next.config.ts`. It's a static Vercel env var, apparently set to the production value even in the Preview scope.

## Why this fix, not "correct the env var"

Read Better Auth's docs and community guidance before deciding:
- `crossSubDomainCookies` is for one app's own subdomains, not two independently-deployed Vercel projects with unrelated per-branch preview URLs.
- Better Auth's "Dynamic Base URL" (`baseURL.allowedHosts`) solves a different problem (one app, many hostnames) — doesn't bridge two sibling `*.vercel.app` project aliases.
- A Better Auth discussion on split frontend/backend deployments confirms the reverse-proxy pattern (already shipped in #573/#574) is the standard fix — cookies become first-party automatically, no shared domain needed.
- A related issue asking for smarter, `trustedOrigins`-derived cookie domains was closed **not planned** by the maintainers.
- Grepped the repo: nothing outside `packages/auth` touches `crossSubDomainCookies`/`deriveCookieDomain`/the session cookie — safe to remove outright.

## Fix

Removed `crossSubDomainCookies` and the now-dead `deriveCookieDomain` helper. The session cookie is now plain host-only, which the dashboard's `/api/*` proxy already makes correctly first-party in every environment.

## Test plan

- [x] `pnpm turbo run check-types` — all packages pass, including `@dukkani/auth`.
- [ ] Needs a real preview deployment to confirm login now actually redirects to the dashboard.